### PR TITLE
#ILEX-30 Curies editor component

### DIFF
--- a/src/components/CurieEditor/CuriesTabPanel.jsx
+++ b/src/components/CurieEditor/CuriesTabPanel.jsx
@@ -120,6 +120,7 @@ const CuriesTabPanel = (props) => {
     const handleSort = (dir) => {
         setSortTriggered(true);
         setOrder(dir);
+        handleExit();
     }
 
     if (error) {

--- a/src/components/CurieEditor/CuriesTabPanel.jsx
+++ b/src/components/CurieEditor/CuriesTabPanel.jsx
@@ -61,9 +61,8 @@ const CuriesTabPanel = (props) => {
     const debouncedUpdateRows = React.useMemo(
         () => debounce((updatedRows) => {
             setRows(updatedRows);
-            handleExit();
             console.log("here we connect UPDATE method")
-        }, 500),
+        }, 5000),
         []
     );
 


### PR DESCRIPTION
Issue #28 
Problem: Curies editor component (table cells lose focus very quickly)
Solution: 
Update the time from 300 to 5000 milliseconds and set row and column to -1 only when we are clicking onto another table cell

https://github.com/MetaCell/interlex/assets/67194168/5c12627c-8367-4597-ac40-9948e4071c44

