### PR TITLE
#ILEX-51 - Add POST endpoint for a new term . #ILEX-72 - Exposes endpoints for retrieving terms, ontologies and curies for an organization.

### DIFF
--- a/interlex.yaml
+++ b/interlex.yaml
@@ -388,6 +388,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /{group}/addTerm:
+    post:
+      summary: Used to add a new term
+      operationId: add_term
+      tags:
+        - Auth
+      description: ''
+      x-swagger-router-controller: src.server.auth
+      parameters:
+        - name: group
+          in: path
+          required: true
+          description: The group of the term to retrieve
+          schema:
+            type: string
+      requestBody:
+        description: The term to add
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Term'
+              x-body-name: term
+      responses:
+        200:
+          description: A json with new term and status response
+          content:
+            application/json:
+              type: object
+              properties:
+                status:
+                  type: string
+                terms:
+                  $ref: '#/components/schemas/Term'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /{group}/bulkEditTerms:
     post:
       summary: Used to bulk edit terms

--- a/orval.config.js
+++ b/orval.config.js
@@ -193,6 +193,11 @@ module.exports = {
               data: mockPatchBulkTermsResponse
             },
           },
+          add_term: {
+            mock: {
+              data: mockPatchTermResponse
+            },
+          },
           // Search for specific 'term' and get all results
           get_match_terms: {
             mock: {

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1420,6 +1420,35 @@ import { patchTerm } from './../../api/endpoints';
   }, [patchTermRequest]);
 ```
 
+### Adding a Term
+- To Add a new Term, use the method below.
+```
+import { addTerm } from './../../api/endpoints';
+
+  const addTermRequest = useCallback(async (group, term) => {
+    await addTerm("base", term).then((response) => {
+      console.log("Term added ", response)
+    })
+    .catch((error) => {
+        console.log("Error ", error)
+    });
+  }, [addTerm]);
+
+  useEffect(() => {
+    // Must be json structure
+    let term = {
+        label : "",
+        existingIDs : [],
+        synonyms : [],
+        superClass : "",
+        isDefinedBy : "",
+        description : "",
+        comment : ""
+    }
+    addTermRequest("base", term)
+  }, [addTermRequest]);
+```
+
 ### Patching Bulk Terms
 - To Edit Bulk Terms, use the method below.
 ```

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1353,7 +1353,7 @@ const getIds= useCallback(debounce(async () => {
 ### Retrieving Single Organization
 - To retrieve a single Organization, use the method below.
 ```
-import { getOrganization } from './../../api/endpoints';
+import { getOrganization, getOrganizationTerms, getOrganizationCuries, getOrganizationOntologies } from './../../api/endpoints';
 
 const getOrganizationRequest = useCallback(async (id) => {
     await getOrganization(id).then((response) => {
@@ -1362,10 +1362,31 @@ const getOrganizationRequest = useCallback(async (id) => {
     .catch((error) => {
         console.log("Error ", error)
     });
-  }, [getOrganization]);
+
+    await getOrganizationTerms(id).then((response) => {
+      console.log("Get Organization terms response ", response)
+    })
+    .catch((error) => {
+        console.log("Error ", error)
+    });
+
+    await getOrganizationCuries(id).then((response) => {
+      console.log("Get Organization curies response ", response)
+    })
+    .catch((error) => {
+        console.log("Error ", error)
+    });
+
+    await getOrganizationOntologies(id).then((response) => {
+      console.log("Get Organization ontologies response ", response)
+    })
+    .catch((error) => {
+        console.log("Error ", error)
+    });
+  }, [getOrganization, getOrganizationTerms, getOrganizationCuries, getOrganizationOntologies]);
 
   useEffect(() => {
-    getOrganizationRequest("1")
+    getOrganizationRequest("1");
   }, [getOrganizationRequest]);
 ```
 

--- a/src/api/endpoints/index.ts
+++ b/src/api/endpoints/index.ts
@@ -79,8 +79,6 @@ export const getCuries = async (term) => {
 }
 
 export const getMatchTerms = async (term, filters = {}) => {
-  /** Call endpoint for retrieving curies, this is a mock endpoint
-  created by us */
   const {  getMatchTerms } = useMockApi();
 
   /** Call Endpoint */
@@ -93,8 +91,6 @@ export const getMatchTerms = async (term, filters = {}) => {
 }
 
 export const patchTerm = async (group, termID, term) => {
-  /** Call endpoint for retrieving curies, this is a mock endpoint
-  created by us */
   const {  patchEndpointsIlx } = useApi();
 
   /** Call Endpoint */
@@ -107,9 +103,20 @@ export const patchTerm = async (group, termID, term) => {
     });
 }
 
+export const addTerm = async (group, term) => {
+  const {  addTerm } = useMockApi();
+
+  /** Call Endpoint */
+  return addTerm(group, term).then((data) => {
+      console.log("add term response ", data)
+      return data;
+    })
+    .catch((error) => {
+      return error;
+    });
+}
+
 export const bulkEditTerms = async (group, payload) => {
-  /** Call endpoint for retrieving curies, this is a mock endpoint
-  created by us */
   const { bulkEditTerms } = useMockApi();
 
   /** Call Endpoint */
@@ -123,8 +130,6 @@ export const bulkEditTerms = async (group, payload) => {
 }
 
 export const getEndpointsIlx = async (group, term) => {
-  /** Call endpoint for retrieving curies, this is a mock endpoint
-  created by us */
   const {  getEndpointsIlx } = useApi();
 
   /** Call Endpoint */
@@ -137,8 +142,6 @@ export const getEndpointsIlx = async (group, term) => {
 }
 
 export const getUser = async (id) => {
-  /** Call endpoint for retrieving curies, this is a mock endpoint
-  created by us */
   const {  getUser } = useMockApi();
 
   /** Call Endpoint */
@@ -151,8 +154,6 @@ export const getUser = async (id) => {
 }
 
 export const getExistingIDs = async () => {
-  /** Call endpoint for retrieving curies, this is a mock endpoint
-  created by us */
   const {  getMatchTerms } = useMockApi();
 
   /** Call Endpoint */
@@ -167,8 +168,6 @@ export const getExistingIDs = async () => {
 }
 
 export const signup = async (body) => {
-  /** Call endpoint for retrieving curies, this is a mock endpoint
-  created by us */
   const {  signup } = useMockApi();
 
   /** Call Endpoint */

--- a/src/api/endpoints/index.ts
+++ b/src/api/endpoints/index.ts
@@ -1,9 +1,10 @@
-import { Organizations, Variants, Versions, User, Organization } from '../../model/backend';
+import { Organizations, Variants, Versions, User, Organization, Terms, Ontologies } from '../../model/backend';
 import * as mockApi from './../../api/endpoints/swaggerMockMissingEndpoints';
 import * as api from './../../api/endpoints/interLexURIStructureAPI'
 
 import curieParser from '../../parsers/curieParser';
 import termParser from '../../parsers/termParser';
+import { Curies } from '../../model/frontend/curies';
 
 const useMockApi = () => mockApi;
 const useApi = () => api;
@@ -30,6 +31,43 @@ export const getOrganization = async (id) => {
   /** Call Endpoint */
   return getOrganization(id).then((data) => {
       return data as Organization;
+    })
+    .catch((error) => {
+      return error;
+    });
+}
+
+export const getOrganizationTerms = async (id) => {
+  /** Call endpoint for retrieving organizations, this is a mock endpoint
+  created by us */
+  const {  getOrganizationsTerms } = useMockApi();
+
+  /** Call Endpoint */
+  return getOrganizationsTerms(id).then((data) => {
+      return termParser(data, undefined);
+    })
+    .catch((error) => {
+      return error;
+    });
+}
+
+export const getOrganizationCuries = async (id) => {
+  const {  getOrganizationsCuries } = useMockApi();
+
+  /** Call Endpoint */
+  return getOrganizationsCuries(id).then((data) => {
+      return curieParser(data);;
+    })
+    .catch((error) => {
+      return error;
+    });
+}
+
+export const getOrganizationOntologies = async (id) => {
+  const {  getOrganizationsOntologies } = useMockApi();
+
+  return getOrganizationsOntologies(id).then((data) => {
+      return data as Ontologies;
     })
     .catch((error) => {
       return error;
@@ -94,7 +132,7 @@ export const patchTerm = async (group, termID, term) => {
   const {  patchEndpointsIlx } = useApi();
 
   /** Call Endpoint */
-  return patchEndpointsIlx(group, termID, term).then((data) => {
+  return patchEndpointsIlx(group, termID).then((data) => {
       console.log("patch term response ", data)
       return data;
     })
@@ -142,7 +180,7 @@ export const getEndpointsIlx = async (group, term) => {
 }
 
 export const getUser = async (id) => {
-  const {  getUser } = useMockApi();
+  const {  getUser } = useMockApi();patchTerm
 
   /** Call Endpoint */
   return getUser(id).then((data) => {

--- a/src/api/endpoints/swaggerMockMissingEndpoints.msw.ts
+++ b/src/api/endpoints/swaggerMockMissingEndpoints.msw.ts
@@ -1911,6 +1911,86 @@ export const getGetOrganizationsCuriesResponseMock = () => ((() => {
 
 export const getGetHierarchyResultsResponseMock = (): Hierarchies => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ([])))
 
+export const getAddTermResponseMock = () => ((() => {
+  return {
+    status: 200,
+    data: {
+      "@context": {
+        "owl": "http://www.w3.org/2002/07/owl#",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+      },
+      "@graph": [
+        {
+          "@id": "http://uri.interlex.org/base/ilx_0101431",
+          "http://uri.interlex.org/tgbugs/uris/readable/hasIlxId": {
+            "@id": "http://uri.interlex.org/base/ilx_0101431"
+          },
+          "http://uri.interlex.org/tgbugs/uris/readable/hasIlxPreferredId": {
+            "@id": "http://uri.interlex.org/base/ilx_0101431"
+          },
+          "http://uri.interlex.org/tgbugs/uris/readable/owlEquivalent": "owlEquivalent",
+          "http://uri.interlex.org/tgbugs/uris/readable/lastModify": "lastModify",
+          "http://uri.interlex.org/tgbugs/uris/readable/lastModifyBy": "lastModifyBy",
+          "http://uri.interlex.org/tgbugs/uris/readable/submittedBy": "submittedBy"
+        },
+        {
+          "@id": "http://uri.interlex.org/base/ontologies/ilx_0101431",
+          "@type": "owl:Ontology",
+          "http://purl.obolibrary.org/obo/IAO_0000136": {
+            "@id": "http://uri.interlex.org/base/ilx_0101431"
+          },
+          "owl:versionIRI": {
+            "@id": "http://uri.interlex.org/base/ontologies/ilx_0101431/version/1717611398/ilx_0101431"
+          },
+          "owl:versionInfo": "2024-06-05T18:16:38,089335Z",
+          "rdfs:comment": "InterLex single term result for base/ilx_0101431 at 2024-06-05T18:16:38,089335Z"
+        },
+        {
+          "@id": "http://purl.obolibrary.org/obo/UBERON_0000955",
+          "@type": "owl:Class",
+          "http://purl.obolibrary.org/obo/IAO_0000115": "The part of the central nervous system contained within the cranium, comprising the forebrain, midbrain, hindbrain, and metencephalon. It is derived from the anterior part of the embryonic neural tube (or the encephalon). Does not include retina. (CUMBO)The rostral topographic division of the cerebrospinal axis, while the caudal division is the spinal cord. The usual criterion for distinguishing the two divisions in the adult is that the vertebrate brain lies within the skull whereas the spinal cord lies within the spinal (vertebral) column, although this is a difficult problem. (Swanson, 2014)",
+          "http://uri.interlex.org/base/ilx_0112784": {
+            "@id": "http://uri.interlex.org/base/ilx_0102661"
+          },
+          "http://uri.interlex.org/base/ilx_0112785": {
+            "@id": "http://uri.interlex.org/base/ilx_0101999"
+          },
+          "http://uri.interlex.org/base/ilx_0112796": {
+            "@id": "http://uri.interlex.org/base/ilx_0101901"
+          },
+          "http://uri.interlex.org/base/readable/synonym": [
+            "Encephalon",
+            "synganglion",
+            "the brain",
+            "suprasegmental levels of nervous system",
+            "suprasegmental structures"
+          ],
+          "http://uri.interlex.org/tgbugs/uris/readable/MISSING_ILX_ID": true,
+          "http://uri.interlex.org/tgbugs/uris/readable/hasExistingId": [
+            {
+              "@id": "http://uri.neuinfo.org/nif/nifstd/birnlex_796"
+            },
+            {
+              "@id": "http://purl.org/sig/ont/fma/fma50801"
+            },
+            {
+              "@id": "http://purl.obolibrary.org/obo/UBERON_0000955"
+            }
+          ],
+          "http://uri.interlex.org/tgbugs/uris/readable/organization": "My Organization",
+          "http://uri.interlex.org/tgbugs/uris/readable/status": "Approved",
+          "rdfs:label": "Brain",
+          "rdfs:subClassOf": {
+            "@id": "http://uri.interlex.org/base/ilx_0108124"
+          }
+        }
+      ]
+    }
+  };
+})())
+
 export const getBulkEditTermsResponseMock = () => ((() => {
   return {
     status: 200,
@@ -3171,6 +3251,20 @@ export const getGetHierarchyResultsMockHandler = (overrideResponse?: Hierarchies
   })
 }
 
+export const getAddTermMockHandler = (overrideResponse?: Error) => {
+  return http.post('*/:group/addTerm', async () => {
+    await delay(1000);
+    return new HttpResponse(JSON.stringify(overrideResponse !== undefined ? overrideResponse : getAddTermResponseMock()),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      }
+    )
+  })
+}
+
 export const getBulkEditTermsMockHandler = (overrideResponse?: Error) => {
   return http.post('*/:group/bulkEditTerms', async () => {
     await delay(1000);
@@ -3325,6 +3419,7 @@ export const getSwaggerMockMissingEndpointsMock = () => [
   getGetOrganizationsOntologiesMockHandler(),
   getGetOrganizationsCuriesMockHandler(),
   getGetHierarchyResultsMockHandler(),
+  getAddTermMockHandler(),
   getBulkEditTermsMockHandler(),
   getGetMatchTermsMockHandler(),
   getGetCuriesMockHandler(),

--- a/src/api/endpoints/swaggerMockMissingEndpoints.ts
+++ b/src/api/endpoints/swaggerMockMissingEndpoints.ts
@@ -17,6 +17,7 @@ import type {
   Organization,
   Organizations,
   Signup200,
+  Term,
   Terms,
   User,
   Variants,
@@ -204,6 +205,21 @@ export const getHierarchyResults = (
     }
   
 /**
+ * @summary Used to add a new term
+ */
+export const addTerm = (
+    group: string,
+    term: BodyType<Term>,
+ options?: SecondParameter<typeof customInstance>,) => {
+      return customInstance<Error>(
+      {url: `/${group}/addTerm`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: term
+    },
+      options);
+    }
+  
+/**
  * @summary Used to bulk edit terms
  */
 export const bulkEditTerms = (
@@ -356,6 +372,7 @@ export type GetOrganizationsTermsResult = NonNullable<Awaited<ReturnType<typeof 
 export type GetOrganizationsOntologiesResult = NonNullable<Awaited<ReturnType<typeof getOrganizationsOntologies>>>
 export type GetOrganizationsCuriesResult = NonNullable<Awaited<ReturnType<typeof getOrganizationsCuries>>>
 export type GetHierarchyResultsResult = NonNullable<Awaited<ReturnType<typeof getHierarchyResults>>>
+export type AddTermResult = NonNullable<Awaited<ReturnType<typeof addTerm>>>
 export type BulkEditTermsResult = NonNullable<Awaited<ReturnType<typeof bulkEditTerms>>>
 export type GetMatchTermsResult = NonNullable<Awaited<ReturnType<typeof getMatchTerms>>>
 export type GetCuriesResult = NonNullable<Awaited<ReturnType<typeof getCuries>>>


### PR DESCRIPTION
Adds a new endpoint to handle POST new term to the mock openapi contract. 