### PR TITLE
ILEX-77 Remove rich text toolbar from discussion component

### DIFF
--- a/src/components/SingleTermView/Discussion/CommentEditor.jsx
+++ b/src/components/SingleTermView/Discussion/CommentEditor.jsx
@@ -23,11 +23,6 @@ const CommentEditor = ({ onAddComment }) => {
         onChange={handleEditorChange}
         toolbarConfig={{
           display: ['INLINE_STYLE_BUTTONS', 'BLOCK_TYPE_BUTTONS'],
-          INLINE_STYLE_BUTTONS: [
-            { label: 'Bold', style: 'BOLD', className: 'custom-css-class' },
-            { label: 'Italic', style: 'ITALIC' },
-            { label: 'Underline', style: 'UNDERLINE' }
-          ],
           BLOCK_TYPE_BUTTONS: [
             { label: 'UL', style: 'unordered-list-item' },
             { label: 'OL', style: 'ordered-list-item' }

--- a/src/components/SingleTermView/Discussion/CommentEditor.jsx
+++ b/src/components/SingleTermView/Discussion/CommentEditor.jsx
@@ -22,13 +22,9 @@ const CommentEditor = ({ onAddComment }) => {
         value={editorState}
         onChange={handleEditorChange}
         toolbarConfig={{
-          display: ['INLINE_STYLE_BUTTONS', 'BLOCK_TYPE_BUTTONS'],
-          BLOCK_TYPE_BUTTONS: [
-            { label: 'UL', style: 'unordered-list-item' },
-            { label: 'OL', style: 'ordered-list-item' }
-          ]
+          display: []
         }}
-        
+        toolbarClassName="custom-toolbar"
       />
       <Button
         onClick={handleAddComment}

--- a/src/theme/index.jsx
+++ b/src/theme/index.jsx
@@ -105,6 +105,9 @@ const theme = createTheme({
                     min-height: 100vh;
                     padding: 1rem 0;
                 }
+				.custom-toolbar {
+					padding: 2rem !important;
+				}
             `,
 		},
 		MuiRichTreeView: {


### PR DESCRIPTION
Issue #ILEX-77
Problem: Remove rich text toolbar from discussion component
Solution: 
1. remove inline style buttons from toolbar configuration in discussion component

Result: 

![image](https://github.com/user-attachments/assets/844b6066-226e-48b7-8ee7-9761bcf88767)
