### PR TITLE
ILEX-105 Single term view going undefined when removing the search term

### DIFF
--- a/src/components/Header/Search.jsx
+++ b/src/components/Header/Search.jsx
@@ -99,6 +99,8 @@ const Search = () => {
   const handleInputChange = (event) => setSearchTerm(event.target.value);
 
   const handleSelectTerm = (event, newInputValue) => {
+    if (!newInputValue) return;
+    
     setSearchTerm("");
     setSelectedValue(newInputValue?.label);
     handleCloseList();


### PR DESCRIPTION
Issue [#ILEX-105](https://metacell.atlassian.net/browse/ILEX-105)
Problem: Single term view going undefined when removing the search term
Solution: 
1. Check if new new input value is undefined, if yes don't set new search term

Result: 

https://github.com/user-attachments/assets/a1dbf5a6-d7bf-4239-bab0-abbc85a57e26

