### PR TITLE
#ILEX-111 - Single term view - editor view broken fix

### DIFF
--- a/src/api/endpoints/index.ts
+++ b/src/api/endpoints/index.ts
@@ -229,6 +229,18 @@ export const patchTerm = async (group, termID, term) => {
     });
 }
 
+export const getRawData = async (group, termID, term) => {
+  const {getEndpointsIlx} = useApi();
+
+  /** Call Endpoint */
+  return getEndpointsIlx(group, termID, term).then((data) => {
+      return data;
+    })
+    .catch((error) => {
+      return error;
+    });
+}
+
 export const addTerm = async (group, term) => {
   const {  postPrivEntityNew } = useApi();
 

--- a/src/api/endpoints/index.ts
+++ b/src/api/endpoints/index.ts
@@ -229,11 +229,11 @@ export const patchTerm = async (group, termID, term) => {
     });
 }
 
-export const getRawData = async (group, termID, term) => {
+export const getRawData = async (group, termID, format) => {
   const {getEndpointsIlx} = useApi();
 
   /** Call Endpoint */
-  return getEndpointsIlx(group, termID, term).then((data) => {
+  return getEndpointsIlx(group, termID, format).then((data) => {
       return data;
     })
     .catch((error) => {

--- a/src/components/SingleTermView/OverView/RawDataViewer.jsx
+++ b/src/components/SingleTermView/OverView/RawDataViewer.jsx
@@ -3,6 +3,8 @@ import { useState, useEffect } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { a11yLight } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import { getRawData } from "../../../api/endpoints";
+import { GlobalDataContext } from "../../../contexts/DataContext";
+import { useContext } from "react";
 
 import { vars } from '../../../theme/variables';
 const { gray25, gray200, gray500 } = vars;
@@ -16,9 +18,8 @@ const customStyle = {
     padding: 0
 };
 
-// eslint-disable-next-line no-unused-vars
 const formatExtensions = {
-    'jsonld': 'jsonld',
+    'JSON-LD': 'jsonld',
     'Turtle': 'ttl',
     'N3': 'n3',
     'OWL': 'owl',
@@ -29,9 +30,10 @@ const RawDataViewer = ({ dataId, dataFormat }) => {
     const [formattedData, setFormattedData] = useState(null);
     // eslint-disable-next-line no-unused-vars
     const [loading, setLoading] = useState(true);
-    
+    const { user } = useContext(GlobalDataContext);
+
     useEffect(() => {
-        getRawData("base",dataId, dataFormat).then( rawResponse => {
+        getRawData(user?.name || "base",dataId, formatExtensions[dataFormat]).then( rawResponse => {
         setFormattedData(JSON.stringify(rawResponse, null, 2));
         setLoading(false)
       })

--- a/src/components/SingleTermView/OverView/RawDataViewer.jsx
+++ b/src/components/SingleTermView/OverView/RawDataViewer.jsx
@@ -2,12 +2,10 @@ import PropTypes from 'prop-types';
 import { useState, useEffect } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { a11yLight } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-import * as mockApi from './../../../api/endpoints/interLexURIStructureAPI';
+import { getRawData } from "../../../api/endpoints";
 
 import { vars } from '../../../theme/variables';
 const { gray25, gray200, gray500 } = vars;
-
-const useMockApi = () => mockApi;
 
 const customStyle = {
     fontSize: '1rem',
@@ -20,7 +18,7 @@ const customStyle = {
 
 // eslint-disable-next-line no-unused-vars
 const formatExtensions = {
-    'JSON-LD': 'jsonld',
+    'jsonld': 'jsonld',
     'Turtle': 'ttl',
     'N3': 'n3',
     'OWL': 'owl',
@@ -31,10 +29,9 @@ const RawDataViewer = ({ dataId, dataFormat }) => {
     const [formattedData, setFormattedData] = useState(null);
     // eslint-disable-next-line no-unused-vars
     const [loading, setLoading] = useState(true);
-    const { getEndpointsIlxGet } = useMockApi();
     
     useEffect(() => {
-      getEndpointsIlxGet("base",dataId, dataFormat).then( rawResponse => {
+        getRawData("base",dataId, dataFormat).then( rawResponse => {
         setFormattedData(JSON.stringify(rawResponse, null, 2));
         setLoading(false)
       })

--- a/src/components/SingleTermView/index.jsx
+++ b/src/components/SingleTermView/index.jsx
@@ -56,7 +56,7 @@ const SingleTermView = () => {
   const [tabValue, setTabValue] = React.useState(0);
   const [isCodeViewVisible, setIsCodeViewVisible] = React.useState(false);
   const [toggleButtonValue, setToggleButtonValue] = useState('defaultView');
-  const [selectedDataFormat, setSelectedDataFormat] = React.useState('jsonld');
+  const [selectedDataFormat, setSelectedDataFormat] = React.useState('JSON-LD');
   const [openRequestMergeDialog, setOpenRequestMergeDialog] = React.useState(false);
   const [editTermDialogOpen, setEditTermDialogOpen] = React.useState(false);
   const query = useQuery();

--- a/src/components/SingleTermView/index.jsx
+++ b/src/components/SingleTermView/index.jsx
@@ -46,7 +46,7 @@ import TermDialog from "../TermEditor/TermDialog";
 
 const { gray200, brand700, gray600 } = vars;
 
-const dataFormats = ['JSON-LD', 'Turtle', 'N3', 'OWL', 'CSV']
+const dataFormats = ['jsonld', 'Turtle', 'N3', 'OWL', 'CSV']
 
 const SingleTermView = () => {
   const [open, setOpen] = React.useState(false);
@@ -56,7 +56,7 @@ const SingleTermView = () => {
   const [tabValue, setTabValue] = React.useState(0);
   const [isCodeViewVisible, setIsCodeViewVisible] = React.useState(false);
   const [toggleButtonValue, setToggleButtonValue] = useState('defaultView');
-  const [selectedDataFormat, setSelectedDataFormat] = React.useState('JSON-LD');
+  const [selectedDataFormat, setSelectedDataFormat] = React.useState('jsonld');
   const [openRequestMergeDialog, setOpenRequestMergeDialog] = React.useState(false);
   const [editTermDialogOpen, setEditTermDialogOpen] = React.useState(false);
   const query = useQuery();

--- a/src/components/SingleTermView/index.jsx
+++ b/src/components/SingleTermView/index.jsx
@@ -46,7 +46,7 @@ import TermDialog from "../TermEditor/TermDialog";
 
 const { gray200, brand700, gray600 } = vars;
 
-const dataFormats = ['jsonld', 'Turtle', 'N3', 'OWL', 'CSV']
+const dataFormats = ['JSON-LD', 'Turtle', 'N3', 'OWL', 'CSV']
 
 const SingleTermView = () => {
   const [open, setOpen] = React.useState(false);


### PR DESCRIPTION
This fixes issue 111.

```
The Single term view - editor view component previously implemented is not working/display the raw data.

It could be that the data are not available, if that is the case account for the view to work and just display a message in the raw data viewer that says ‘data not available for this term’.
```