### PR TITLE
#ILEX-92 - Add Term

### DIFF
--- a/mock/mutator/customClient.ts
+++ b/mock/mutator/customClient.ts
@@ -1,14 +1,14 @@
-import Axios, { AxiosRequestConfig, AxiosError, AxiosResponse } from 'axios';
+import Axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 import { API_CONFIG } from '../../src/config';
 
 export const AXIOS_INSTANCE = Axios.create({
   baseURL: API_CONFIG.BASE_URL,
-  withCredentials: true, // ✅ Always send cookies
+  withCredentials: true,
 });
 
 export const customInstance = <T>(
   config: AxiosRequestConfig,
-  options?: AxiosRequestConfig,
+  options?: AxiosRequestConfig
 ): Promise<T> => {
   const source = Axios.CancelToken.source();
 
@@ -17,17 +17,22 @@ export const customInstance = <T>(
     ...options,
     cancelToken: source.token,
     withCredentials: true,
-    validateStatus: (status) => status >= 200 && status < 400, // ✅ Accept 3xx
+    validateStatus: (status) => status >= 200 && status < 400,
   })
     .then(async (response: AxiosResponse<T>) => {
       const isRedirect = response.status === 303;
       const redirectUrl = response.headers['x-redirect-location'];
 
       if (isRedirect && redirectUrl) {
-        const redirected = await AXIOS_INSTANCE.get<T>(redirectUrl, {
+        const followUp = await AXIOS_INSTANCE.get<T>(redirectUrl, {
           withCredentials: true,
+          headers: {
+            Accept: 'text/turtle',
+          },
+          validateStatus: (status) => status === 200,
         });
-        return redirected.data;
+
+        return followUp.data;
       }
 
       return response.data;
@@ -45,6 +50,6 @@ export const customInstance = <T>(
   return promise;
 };
 
-// Utility types (unchanged)
+// Error typing helpers
 export type ErrorType<Error> = AxiosError<Error>;
 export type BodyType<BodyData> = BodyData;

--- a/mock/mutator/customClient.ts
+++ b/mock/mutator/customClient.ts
@@ -1,35 +1,50 @@
-import Axios, { AxiosRequestConfig } from 'axios';
+import Axios, { AxiosRequestConfig, AxiosError, AxiosResponse } from 'axios';
 import { API_CONFIG } from '../../src/config';
-export const AXIOS_INSTANCE = Axios.create({ baseURL: API_CONFIG.BASE_URL });
 
-// add a second `options` argument here if you want to pass extra options to each generated query
+export const AXIOS_INSTANCE = Axios.create({
+  baseURL: API_CONFIG.BASE_URL,
+  withCredentials: true, // ✅ Always send cookies
+});
+
 export const customInstance = <T>(
   config: AxiosRequestConfig,
   options?: AxiosRequestConfig,
 ): Promise<T> => {
   const source = Axios.CancelToken.source();
+
   const promise = AXIOS_INSTANCE({
     ...config,
     ...options,
     cancelToken: source.token,
-  }).then(({ data }) => data).catch(error => {
-    throw error;
-  });
+    withCredentials: true,
+    validateStatus: (status) => status >= 200 && status < 400, // ✅ Accept 3xx
+  })
+    .then(async (response: AxiosResponse<T>) => {
+      const isRedirect = response.status === 303;
+      const redirectUrl = response.headers['x-redirect-location'];
+
+      if (isRedirect && redirectUrl) {
+        const redirected = await AXIOS_INSTANCE.get<T>(redirectUrl, {
+          withCredentials: true,
+        });
+        return redirected.data;
+      }
+
+      return response.data;
+    })
+    .catch((error: AxiosError) => {
+      throw error;
+    });
 
   // @ts-ignore
   promise.cancel = () => {
-    console.log("query was cancelled")
-    source.cancel('Query was cancelled');
+    console.log("query was cancelled");
+    source.cancel("Query was cancelled");
   };
 
   return promise;
 };
 
-// In some case with react-query and swr you want to be able to override the return error type so you can also do it here like this
+// Utility types (unchanged)
 export type ErrorType<Error> = AxiosError<Error>;
-
 export type BodyType<BodyData> = BodyData;
-
-// Or, in case you want to wrap the body type (optional)
-// (if the custom instance is processing data before sending it, like changing the case for example)
-export type BodyType<BodyData> = CamelCase<BodyData>;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,7 +44,7 @@ function MainContent() {
 	const { user, setUserData } = useContext(GlobalDataContext);
 
 	// check if cookie is expired
-	if (!user) {
+	if (!user && user != null) {
 		const sessionCookie = cookies.session;
 		const expires = new Date(cookiesInfo?.expires);
 		const today = new Date();

--- a/src/api/endpoints/apiActions.ts
+++ b/src/api/endpoints/apiActions.ts
@@ -6,17 +6,14 @@ import { useCookies } from 'react-cookie'
 
 type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1];
 
-export const createPostRequest = <T = any, D = any>(endpoint: string, contentType = "application/json", cookie : string) => {
+export const createPostRequest = <T = any, D = any>(endpoint: string, headers : object) => {
   return (data?: D, options?: SecondParameter<typeof customInstance>) => {
     return customInstance<T>(
       {
         url: endpoint,
         method: "POST",
         data: data,
-        headers: {
-          "Content-Type": contentType,
-          ...(cookie ? { "Cookie": cookie } : {})
-        },
+        headers: headers,
         withCredentials: true
       },
       options,

--- a/src/api/endpoints/apiActions.ts
+++ b/src/api/endpoints/apiActions.ts
@@ -6,22 +6,45 @@ import { useCookies } from 'react-cookie'
 
 type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1];
 
-export const createPostRequest = <T = any, D = any>(endpoint: string, contentType = "application/json") => {
-  return (data?: D, options?: SecondParameter<typeof customInstance>) => {
-    return customInstance<T>(
-      {
-        url: endpoint,
-        method: "POST",
-        data: data,
-        headers: {
-          "Content-Type": contentType,
+export const createPostRequest = <T = any, D = any>(
+  endpoint: string,
+  contentType = "application/json",
+  cookie?: string
+) => {
+  return async (data?: D, options?: SecondParameter<typeof customInstance>) => {
+    try {
+      const response = await customInstance<T>(
+        {
+          url: endpoint,
+          method: "POST",
+          data: data,
+          headers: {
+            "Content-Type": contentType,
+            ...(cookie ? { "Cookie": cookie } : {}),
+          },
+          withCredentials: true,
+          validateStatus: (status) => status >= 200 && status < 400 // ✅ Allow 3xx
         },
-        withCredentials: true
-      },
-      options,
-    )
-  }
-}
+        options
+      );
+
+      return response;
+    } catch (error: any) {
+      const redirectUrl = error?.response?.headers?.['x-redirect-location'];
+
+      if (error?.response?.status === 303 && redirectUrl) {
+        // ✅ Manually follow the redirect
+        return await customInstance<T>({
+          url: redirectUrl,
+          method: "GET",
+          withCredentials: true
+        });
+      }
+
+      throw error;
+    }
+  };
+};
 
 export const createGetRequest = <T = any, P = any>(endpoint: string, contentType?: string) => {
   return (params?: P, options?: SecondParameter<typeof customInstance>, signal?: AbortSignal) => {

--- a/src/api/endpoints/apiActions.ts
+++ b/src/api/endpoints/apiActions.ts
@@ -6,45 +6,23 @@ import { useCookies } from 'react-cookie'
 
 type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1];
 
-export const createPostRequest = <T = any, D = any>(
-  endpoint: string,
-  contentType = "application/json",
-  cookie?: string
-) => {
-  return async (data?: D, options?: SecondParameter<typeof customInstance>) => {
-    try {
-      const response = await customInstance<T>(
-        {
-          url: endpoint,
-          method: "POST",
-          data: data,
-          headers: {
-            "Content-Type": contentType,
-            ...(cookie ? { "Cookie": cookie } : {}),
-          },
-          withCredentials: true,
-          validateStatus: (status) => status >= 200 && status < 400 // ✅ Allow 3xx
+export const createPostRequest = <T = any, D = any>(endpoint: string, contentType = "application/json", cookie : string) => {
+  return (data?: D, options?: SecondParameter<typeof customInstance>) => {
+    return customInstance<T>(
+      {
+        url: endpoint,
+        method: "POST",
+        data: data,
+        headers: {
+          "Content-Type": contentType,
+          ...(cookie ? { "Cookie": cookie } : {})
         },
-        options
-      );
-
-      return response;
-    } catch (error: any) {
-      const redirectUrl = error?.response?.headers?.['x-redirect-location'];
-
-      if (error?.response?.status === 303 && redirectUrl) {
-        // ✅ Manually follow the redirect
-        return await customInstance<T>({
-          url: redirectUrl,
-          method: "GET",
-          withCredentials: true
-        });
-      }
-
-      throw error;
-    }
-  };
-};
+        withCredentials: true
+      },
+      options,
+    )
+  }
+}
 
 export const createGetRequest = <T = any, P = any>(endpoint: string, contentType?: string) => {
   return (params?: P, options?: SecondParameter<typeof customInstance>, signal?: AbortSignal) => {

--- a/src/api/endpoints/apiService.ts
+++ b/src/api/endpoints/apiService.ts
@@ -28,9 +28,9 @@ interface JsonLdResponse {
   '@graph'?: GraphNode[];
 }
 
-export const login = createPostRequest<any, LoginRequest>(API_CONFIG.REAL_API.SIGNIN, "application/x-www-form-urlencoded")
+export const login = createPostRequest<any, LoginRequest>(API_CONFIG.REAL_API.SIGNIN, {"Content-Type": "application/x-www-form-urlencoded"})
 
-export const register = createPostRequest<any, RegisterRequest>(API_CONFIG.REAL_API.NEWUSER_ILX, "application/x-www-form-urlencoded")
+export const register = createPostRequest<any, RegisterRequest>(API_CONFIG.REAL_API.NEWUSER_ILX, {"Content-Type": "application/x-www-form-urlencoded"})
 
 
 export const getUserSettings = (group: string) => {
@@ -40,7 +40,7 @@ export const getUserSettings = (group: string) => {
 
 export const createNewOrganization = ({ group, data }: { group: string, data: any }) => {
   const endpoint = `/${group}${API_CONFIG.REAL_API.CREATE_NEW_ORGANIZATION}`;
-  return createPostRequest<any, any>(endpoint, "application/json")(data);
+  return createPostRequest<any, any>(endpoint, { "Content-Type" : "application/json" })(data);
 };
 
 export const getOrganizations = (group: string) => {
@@ -84,8 +84,7 @@ export const createNewEntity = async ({group,data,session}: { group: string; dat
     const endpoint = `/${group}${API_CONFIG.REAL_API.CREATE_NEW_ENTITY}`;
     const response = await createPostRequest<any, any>(
       endpoint,
-      "application/x-www-form-urlencoded",
-      `session=${session}`
+      { "Content-Type" : "application/x-www-form-urlencoded" }
     )(data);
 
     // If the response is HTML (a string), extract TMP ID

--- a/src/api/endpoints/apiService.ts
+++ b/src/api/endpoints/apiService.ts
@@ -78,3 +78,8 @@ export const getSelectedTermLabel = async (searchTerm: string): Promise<string |
     return undefined;
   }
 };
+
+export const createNewEntity = ({ group, data, session }: { group: string, data: any, session : string }) => {
+  const endpoint = `/${group}${API_CONFIG.REAL_API.CREATE_NEW_ENTITY}`;
+  return createPostRequest<any, any>(endpoint, "application/x-www-form-urlencoded", `session=${session}`)(data);
+};

--- a/src/api/endpoints/apiService.ts
+++ b/src/api/endpoints/apiService.ts
@@ -79,36 +79,49 @@ export const getSelectedTermLabel = async (searchTerm: string): Promise<string |
   }
 };
 
-export const createNewEntity = async ({
-  group,
-  data,
-  session,
-}: {
-  group: string;
-  data: any;
-  session: string;
-}) => {
-  const endpoint = `/${group}${API_CONFIG.REAL_API.CREATE_NEW_ENTITY}`;
-  const response = await createPostRequest<any, any>(
-    endpoint,
-    "application/x-www-form-urlencoded",
-    `session=${session}`
-  )(data);
+export const createNewEntity = async ({group,data,session}: { group: string; data: any; session: string }) => {
+  try {
+    const endpoint = `/${group}${API_CONFIG.REAL_API.CREATE_NEW_ENTITY}`;
+    const response = await createPostRequest<any, any>(
+      endpoint,
+      "application/x-www-form-urlencoded",
+      `session=${session}`
+    )(data);
 
-  // If the response is HTML (a string), extract TMP ID
-  if (typeof response === "string") {
-    const match = response.match(/TMP:\d{9}/);
-    if (match) {
-      return {
-        term: {
-          id: `http://uri.interlex.org/base/${match[0]}`,
-        },
-        raw: response,
-        status: 200,
-      };
+    // If the response is HTML (a string), extract TMP ID
+    if (typeof response === "string") {
+      const match = response.match(/TMP:\d{9}/);
+      if (match) {
+        return {
+          term: {
+            id: `${match[0]}`,
+          },
+          raw: response,
+          status: 200,
+        };
+      }
     }
-  }
 
-  // Otherwise, return response as-is
-  return response;
+    // Otherwise, return response as-is
+    return response;
+  } catch (error) {
+    if (error?.response.status === 409) {
+      const match = error?.response?.data?.existing?.[0];
+      if (match) {
+        return {
+          term: {
+            id: `${match}`,
+          },
+          raw: error?.response,
+          status: error?.response?.status,
+        };
+      }
+    }
+
+    return {
+      raw: error?.response,
+      status: error?.response?.status,
+    };
+  }
+  
 };

--- a/src/api/endpoints/index.ts
+++ b/src/api/endpoints/index.ts
@@ -126,11 +126,11 @@ export const getCuries = async (term) => {
     });
 }
 
-export const getMatchTerms = async (term, filters = {}) => {
+export const getMatchTerms = async (group, term, filters = {}) => {
   const {  getEndpointsIlx } = useApi();
 
   /** Call Endpoint */
-  return getEndpointsIlx(BASE_GROUP,term, BASE_EXTENSION).then((data) => {
+  return getEndpointsIlx(group,term, BASE_EXTENSION).then((data) => {
       return termParser(data, term);
     })
     .catch((error) => {
@@ -229,23 +229,23 @@ export const patchTerm = async (group, termID, term) => {
     });
 }
 
-export const addTerm = async (group, term) => {
+export const addTerm = async (user: string, token: string, term: { label: string; synonyms: string[] }) => {
   const {  postPrivEntityNew } = useApi();
 
-  /** Call Endpoint */
-  return postPrivEntityNew(group, term).then((data) => {
-      let termParsed = getTerm(data.data);
-      let response = {
-        status : data.status,
-        term : termParsed
-      }
+  const headers = {
+    'Authorization': `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
 
-      return response;
-    })
-    .catch((error) => {
-      return error;
-    });
-}
+  const body = {
+    'rdf-type': 'owl:Class',
+    label: term.label,
+    exact: term.synonyms,
+  };
+
+  return await postPrivEntityNew(user, body, { headers });
+};
+
 
 export const bulkEditTerms = async (group, payload) => {
   const { bulkEditTerms } = useMockApi();
@@ -289,14 +289,11 @@ export const getUser = async (id) => {
     });
 }
 
-export const getExistingIDs = async () => {
-  const {  getMatchTerms } = useMockApi();
-
+export const getExistingIDs = async (searchTerm) => {
   /** Call Endpoint */
-  return getMatchTerms("base", "*").then((data) => {
-      const terms =  termParser(data, undefined);
-      let existingIds = terms?.results?.map( term => term.id?.split("/").pop() );
-      return terms?.results?.[0]?.id != undefined ? existingIds : [];
+  return elasticSearch(searchTerm).then((data) => {
+      const terms =  data?.results;
+      return terms != undefined ? terms : [];
     })
     .catch((error) => {
       return error;

--- a/src/api/endpoints/interLexURIStructureAPI.ts
+++ b/src/api/endpoints/interLexURIStructureAPI.ts
@@ -7565,16 +7565,21 @@ after the label and exact synonyms are done an no matches confirmed the user sho
  * @summary The workflow we want for this is a bit more complex than a simple form
  */
 export const postPrivEntityNew = (
-    group: string,
- options?: SecondParameter<typeof customInstance>,) => {
-      
-      
-      return customInstance<void>(
-      {url: `https://uri.olympiangods.org/${group}/priv/entity-new`, method: 'POST'
+  group: string,
+  data: any,
+  options?: SecondParameter<typeof customInstance> & { headers?: Record<string, string> }
+) => {
+  return customInstance<void>(
+    {
+      url: `https://uri.olympiangods.org/${group}/priv/entity-new`,
+      method: 'POST',
+      data,
+      headers: options?.headers,
     },
-      options);
-    }
-  
+    options
+  );
+};
+
 
 
 export const getPostPrivEntityNewMutationOptions = <TError = ErrorType<unknown>,

--- a/src/api/endpoints/interLexURIStructureAPI.ts
+++ b/src/api/endpoints/interLexURIStructureAPI.ts
@@ -9732,7 +9732,7 @@ export const getEndpointsIlx = (
       
       
       return customInstance<void>(
-      {url: `https://uri.olympiangods.org/${group}/${fragPrefId}.${extension}`, method: 'GET', signal
+      {url: `/${group}/${fragPrefId}.${extension}`, method: 'GET', signal
     },
       options);
     }

--- a/src/components/Auth/Login.jsx
+++ b/src/components/Auth/Login.jsx
@@ -74,6 +74,7 @@ const Login = () => {
           value: sessionCookie.value,
           expires: expires
         }));
+        localStorage.setItem("token", sessionCookie.value)
         setUserData({
           name: userData['groupname'],
           id: userData['orcid'],

--- a/src/components/Dashboard/EditBulkTerms/TermsTable.jsx
+++ b/src/components/Dashboard/EditBulkTerms/TermsTable.jsx
@@ -89,7 +89,7 @@ const TermsTable = ({ setOpenEditAttributes, setAttributes, attributes, searchCo
 
   React.useEffect(() => {
     setLoading(true)
-    getMatchTerms("i", { filters }).then(data => {
+    getMatchTerms("base", "i", { filters }).then(data => {
       setTerms(data.results);
       setLoading(false);
     }).catch(err => {

--- a/src/components/SingleTermView/OverView/CustomizedTable.jsx
+++ b/src/components/SingleTermView/OverView/CustomizedTable.jsx
@@ -245,7 +245,7 @@ const CustomizedTable = ({ data, term, isAddButtonVisible }) => {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const fetchTerms = useCallback(debounce(async (searchTerm) => {
-    const data = await getMatchTerms(searchTerm);
+    const data = await getMatchTerms("base", searchTerm);
     setTerms(data?.results[0]);
   }, 500), [getMatchTerms]);
 

--- a/src/components/SingleTermView/OverView/OverView.jsx
+++ b/src/components/SingleTermView/OverView/OverView.jsx
@@ -43,7 +43,7 @@ const OverView = ({ searchTerm, isCodeViewVisible, selectedDataFormat }) => {
     <Box p="2.5rem 5rem" sx={{
       overflow: 'auto',
     }}>
-      {isCodeViewVisible ? <RawDataViewer dataId={"ilx_0101901"} dataFormat={selectedDataFormat} /> :
+      {isCodeViewVisible ? <RawDataViewer dataId={searchTerm} dataFormat={selectedDataFormat} /> :
         <>
           <Details data={memoData} loading={loading} />
           <Box p='5rem 0'>

--- a/src/components/SingleTermView/OverView/OverView.jsx
+++ b/src/components/SingleTermView/OverView/OverView.jsx
@@ -23,7 +23,7 @@ const OverView = ({ isCodeViewVisible, selectedDataFormat }) => {
   const fetchTerms = useCallback(
     debounce((searchTerm) => {
       if (searchTerm) {
-        getMatchTerms(searchTerm).then(data => {
+        getMatchTerms("base", searchTerm).then(data => {
           setData(data?.results[0]);
           setLoading(false);
         });

--- a/src/components/SingleTermView/OverView/PredicateGroupInput.jsx
+++ b/src/components/SingleTermView/OverView/PredicateGroupInput.jsx
@@ -39,7 +39,7 @@ const PredicateGroupInput = ({ predicate, onChange }) => {
   
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const fetchTerms = useCallback(debounce(async (searchTerm) => {
-    const data = await getMatchTerms(searchTerm);
+    const data = await getMatchTerms("base", searchTerm);
     setTerms(data?.results);
   }, 500), [getMatchTerms]);
   

--- a/src/components/SingleTermView/OverView/RawDataViewer.jsx
+++ b/src/components/SingleTermView/OverView/RawDataViewer.jsx
@@ -3,8 +3,6 @@ import { useState, useEffect } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { a11yLight } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import { getRawData } from "../../../api/endpoints";
-import { GlobalDataContext } from "../../../contexts/DataContext";
-import { useContext } from "react";
 
 import { vars } from '../../../theme/variables';
 const { gray25, gray200, gray500 } = vars;
@@ -30,14 +28,12 @@ const RawDataViewer = ({ dataId, dataFormat }) => {
     const [formattedData, setFormattedData] = useState(null);
     // eslint-disable-next-line no-unused-vars
     const [loading, setLoading] = useState(true);
-    const { user } = useContext(GlobalDataContext);
 
     useEffect(() => {
         getRawData("base",dataId, formatExtensions[dataFormat]).then( rawResponse => {
         setFormattedData(JSON.stringify(rawResponse, null, 2));
         setLoading(false)
       })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dataId, dataFormat]);
 
     return (

--- a/src/components/SingleTermView/OverView/RawDataViewer.jsx
+++ b/src/components/SingleTermView/OverView/RawDataViewer.jsx
@@ -33,7 +33,7 @@ const RawDataViewer = ({ dataId, dataFormat }) => {
     const { user } = useContext(GlobalDataContext);
 
     useEffect(() => {
-        getRawData(user?.name || "base",dataId, formatExtensions[dataFormat]).then( rawResponse => {
+        getRawData("base",dataId, formatExtensions[dataFormat]).then( rawResponse => {
         setFormattedData(JSON.stringify(rawResponse, null, 2));
         setLoading(false)
       })

--- a/src/components/SingleTermView/RequestMergeChanges.jsx
+++ b/src/components/SingleTermView/RequestMergeChanges.jsx
@@ -38,7 +38,7 @@ const RequestMergeChanges = ({ searchTerm, open, handleClose }) => {
     const fetchTerms = useCallback(
         debounce((searchTerm) => {
             if (searchTerm) {
-                getMatchTerms(searchTerm).then(data => {
+                getMatchTerms("base", searchTerm).then(data => {
                     setData(data?.results[0]);
                     setLoading(false);
                 });

--- a/src/components/TermEditor/AddNewTermDialogContent.jsx
+++ b/src/components/TermEditor/AddNewTermDialogContent.jsx
@@ -14,14 +14,12 @@ import { termParser } from "../../../src/parsers/termParser";
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import { getExistingIDs, getUser } from "../../api/endpoints";
 import { useState, useEffect, useMemo, useCallback } from "react";
-import * as mockApi from "../../api/endpoints/swaggerMockMissingEndpoints";
-import * as mockApiInterlex from "../../api/endpoints/interLexURIStructureAPI";
+import { getEndpointsIlx, elasticSearch } from './../../api/endpoints/index';
+import { GlobalDataContext } from "../../contexts/DataContext";
+import { useContext } from "react";
 
 import { vars } from "../../theme/variables";
 const { gray800, gray700 } = vars;
-
-const useMockApi = () => mockApi;
-const useMockApiInterlex = () => mockApiInterlex;
 
 const initialFormState = {
     label: "",
@@ -49,8 +47,6 @@ const formatIdText = (termId) => {
 
 const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChange, onReset }) => {
 
-    const { getMatchTerms } = useMockApi();
-    const { getEndpointsIlx } = useMockApiInterlex();
     const [loading, setLoading] = useState(true);
     const navigate = useNavigate();
     const [termResults, setTermResults] = useState([]);
@@ -65,6 +61,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     const [url, setUrl] = useState('');
     const [formState, setFormState] = useState(initialFormState);
     const [newTermId, setNewTermId] = useState("");
+    const { user, setUserData } = useContext(GlobalDataContext);
 
     const memoData = useMemo(() => data, [data]);
 
@@ -74,30 +71,29 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
             setLoading(true);
             if (termValue) {
                 getEndpointsIlx("base", termValue).then(data => {
+                    setLoading(false);
                     const parsedData = termParser(data);
                     setData(parsedData?.results[0]);
-                    setLoading(false);
                 });
             } else {
-                getMatchTerms("base", "i", { filter: "", value: "" }).then(data => {
-                    const parsedData = termParser(data, "");
-                    setTermResults(parsedData.results);
+                elasticSearch("a").then(data => {
+                    setTermResults(data.results);
                     setLoading(false);
                 });
             }
         }, 300),
-        [getEndpointsIlx, getMatchTerms]
+        [getEndpointsIlx, elasticSearch]
     );
 
     const addTermRequest = useCallback(async (group, term) => {
-        await addTerm("base", term).then((response) => {
-            console.log("Term added ", response)
+        const token = localStorage.getItem("token")
+        const groupName = user?.name || group
+        await addTerm(groupName, token, term).then((response) => {
             setNewTermId(response.term.id.split("/").pop())
         })
             .catch((error) => {
                 console.log("Error ", error)
             });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [addTerm]);
 
     const handleChangeTabs = (_, newValue) => setTabValue(newValue);
@@ -151,11 +147,11 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     }
 
     useEffect(() => {
-        getMatchTerms("base", "i", { filter: "", value: "" }).then(data => {
-            const parsedData = termParser(data, termValue);
-            setTermResults(parsedData.results);
+        elasticSearch(termValue).then(data => {
+            setTermResults(data.results);
+            setLoading(false);
         });
-    }, [termValue, getMatchTerms]);
+    }, [termValue, elasticSearch]);
 
     useEffect(() => {
         fetchTerms(termValue);
@@ -171,42 +167,20 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     }, [memoData]);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const getIds = useCallback(debounce(async () => {
-        const ids = await getExistingIDs();
+    const getIds = useCallback(debounce(async (termValue) => {
+        const ids = await getExistingIDs(termValue || "a");
         setIds(ids)
     }), [getUser]);
 
     useEffect(() => {
-        getIds();
-    }, [getIds]);
+        getIds(termValue);
+    }, [termValue,getIds]);
 
     useEffect(() => {
         if (activeStep === 2) {
             addTermRequest("base", formState)
         }
     }, [addTermRequest, formState, activeStep]);
-
-    //can be deleted, use only for testing purposes
-    useEffect(() => {
-        const fetchData = async () => {
-            try {
-                const response = await fetch('/api/some-endpoint');
-                if (!response.ok) {
-                    throw new Error('HTTP error');
-                }
-                const data = await response.json();
-                setResponseStatus({ success: true, data });
-            } catch (error) {
-                // should be success: false, but true for now so we can wee success status message
-                setResponseStatus({ success: true, error: error.message });
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        fetchData();
-    }, []);
-
 
     const predicatesOptions = predicates.map(row => ({
         label: row.title,

--- a/src/components/TermEditor/AddNewTermDialogContent.jsx
+++ b/src/components/TermEditor/AddNewTermDialogContent.jsx
@@ -44,7 +44,7 @@ const formatIdText = (termId) => {
     );
 }
 
-const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChange, onReset }) => {
+const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChange, onReset, onClose }) => {
 
     const [loading, setLoading] = useState(true);
     const navigate = useNavigate();
@@ -90,7 +90,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
           setAddTermResponse(response);
           setNewTermId(response.term.id.split("/").pop());
         } catch (error) {
-            setAddTermResponse(error.response);
+            setAddTermResponse(error);
         }
       }, [user]);      
 
@@ -99,6 +99,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     const handleAddNewTerm = () => {
         onReset();
         setTermValue('');
+        setAddTermResponse(null)
         setIds([]);
         setFormState(initialFormState)
     }
@@ -223,7 +224,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
                 statusProps={statusProps}
                 onAction={handleAddNewTerm}
                 onTryAgain={handleAddNewTerm}
-                onClose={handleGoToTermClick}
+                onClose={onClose}
                 actionButtonStartIcon={<AddOutlinedIcon />}
                 additionalInfo={formattedNewTermId}
             />}

--- a/src/components/TermEditor/AddNewTermDialogContent.jsx
+++ b/src/components/TermEditor/AddNewTermDialogContent.jsx
@@ -77,7 +77,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
                 });
             } else {
                 elasticSearch("a").then(data => {
-                    setTermResults(data.results);
+                    setTermResults(data.results?.results);
                     setLoading(false);
                 });
             }
@@ -86,8 +86,8 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     );
 
     const addTermRequest = useCallback(async (group, term) => {
-        const token = localStorage.getItem("appToken")
-        const groupName = user?.name || group
+        const token = localStorage.getItem("token")
+        const groupName = user?.groupname || group
         await addTerm(groupName, token, term).then((response) => {
             setNewTermId(response.term.id.split("/").pop())
         })
@@ -147,8 +147,8 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     }
 
     useEffect(() => {
-        elasticSearch(termValue).then(data => {
-            setTermResults(data.results);
+        elasticSearch(termValue, 20, 0).then(data => {
+            setTermResults(data.results?.results);
             setLoading(false);
         });
     }, [termValue]);

--- a/src/components/TermEditor/AddNewTermDialogContent.jsx
+++ b/src/components/TermEditor/AddNewTermDialogContent.jsx
@@ -143,6 +143,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
 
     const handleGoToTermClick = () => {
         navigate(`/view?searchTerm=${newTermId}`);
+        onClose()
     }
 
     useEffect(() => {
@@ -224,7 +225,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
                 statusProps={statusProps}
                 onAction={handleAddNewTerm}
                 onTryAgain={handleAddNewTerm}
-                onClose={onClose}
+                onClose={handleGoToTermClick}
                 actionButtonStartIcon={<AddOutlinedIcon />}
                 additionalInfo={formattedNewTermId}
             />}
@@ -236,7 +237,8 @@ AddNewTermDialogContent.propTypes = {
     activeStep: PropTypes.number.isRequired,
     areMatchesChecked: PropTypes.bool.isRequired,
     onMatchesChange: PropTypes.func.isRequired,
-    onReset: PropTypes.func.isRequired
+    onReset: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
 };
 
 export default AddNewTermDialogContent;

--- a/src/components/TermEditor/AddNewTermDialogContent.jsx
+++ b/src/components/TermEditor/AddNewTermDialogContent.jsx
@@ -53,7 +53,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     const [tabValue, setTabValue] = useState(0);
     const [openSidebar, setOpenSidebar] = useState(true);
     const [data, setData] = useState(null);
-    const [responseStatus, setResponseStatus] = useState(null)
+    const [responseStatus] = useState(null)
     const [termValue, setTermValue] = useState('');
     const [ids, setIds] = useState([]);
     const [predicates, setPredicates] = useState([{ subject: '', predicate: '', object: { type: 'Object', value: '', isLink: false } }]);
@@ -61,7 +61,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     const [url, setUrl] = useState('');
     const [formState, setFormState] = useState(initialFormState);
     const [newTermId, setNewTermId] = useState("");
-    const { user, setUserData } = useContext(GlobalDataContext);
+    const { user } = useContext(GlobalDataContext);
 
     const memoData = useMemo(() => data, [data]);
 
@@ -86,7 +86,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     );
 
     const addTermRequest = useCallback(async (group, term) => {
-        const token = localStorage.getItem("token")
+        const token = localStorage.getItem("appToken")
         const groupName = user?.name || group
         await addTerm(groupName, token, term).then((response) => {
             setNewTermId(response.term.id.split("/").pop())
@@ -94,7 +94,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
             .catch((error) => {
                 console.log("Error ", error)
             });
-    }, [addTerm]);
+    }, [user]);
 
     const handleChangeTabs = (_, newValue) => setTabValue(newValue);
     const handleSidebarToggle = () => setOpenSidebar(!openSidebar);
@@ -151,7 +151,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
             setTermResults(data.results);
             setLoading(false);
         });
-    }, [termValue, elasticSearch]);
+    }, [termValue]);
 
     useEffect(() => {
         fetchTerms(termValue);
@@ -224,7 +224,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
             {activeStep === 2 && <StatusStep
                 statusProps={statusProps}
                 onAction={handleAddNewTerm}
-                onTryAgain={() => console.log("Try again")}
+                onTryAgain={handleAddNewTerm}
                 onClose={handleGoToTermClick}
                 actionButtonStartIcon={<AddOutlinedIcon />}
                 additionalInfo={formattedNewTermId}

--- a/src/components/TermEditor/AddNewTermDialogContent.jsx
+++ b/src/components/TermEditor/AddNewTermDialogContent.jsx
@@ -3,21 +3,19 @@ import PropTypes from "prop-types";
 import { Box } from "@mui/material";
 import ImportFileTab from "./ImportFileTab";
 import BasicTabs from "../common/CustomTabs";
-import { addTerm } from "../../api/endpoints";
 import NewTermSidebar from "./NewTermSidebar";
 import StatusStep from "../common/StatusStep";
 import { useNavigate } from "react-router-dom";
 import ManualImportTab from "./ManualImportTab";
 import AddPredicatesStep from "./AddPredicatesStep";
 import { getAddTermStatusProps } from "./termStatusProps";
-import { termParser } from "../../../src/parsers/termParser";
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import { getExistingIDs, getUser } from "../../api/endpoints";
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { getEndpointsIlx, elasticSearch } from './../../api/endpoints/index';
 import { GlobalDataContext } from "../../contexts/DataContext";
 import { useContext } from "react";
-import { API_CONFIG } from '../../config';
+import { createNewEntity } from './../../api/endpoints/apiService'
 
 import { vars } from "../../theme/variables";
 const { gray800, gray700 } = vars;
@@ -53,8 +51,8 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     const [termResults, setTermResults] = useState([]);
     const [tabValue, setTabValue] = useState(0);
     const [openSidebar, setOpenSidebar] = useState(true);
-    const [data, setData] = useState(null);
-    const [responseStatus] = useState(null)
+    const [data] = useState(null);
+    const [addTermResponse, setAddTermResponse] = useState(null)
     const [termValue, setTermValue] = useState('');
     const [ids, setIds] = useState([]);
     const [predicates, setPredicates] = useState([{ subject: '', predicate: '', object: { type: 'Object', value: '', isLink: false } }]);
@@ -70,32 +68,31 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     const fetchTerms = useCallback(
         debounce((termValue) => {
             setLoading(true);
-            if (termValue) {
-                getEndpointsIlx("base", termValue).then(data => {
-                    setLoading(false);
-                    const parsedData = termParser(data);
-                    setData(parsedData?.results[0]);
-                });
-            } else {
-                elasticSearch("a").then(data => {
-                    setTermResults(data.results?.results);
-                    setLoading(false);
-                });
-            }
+            elasticSearch(termValue).then(data => {
+                setTermResults(data.results?.results);
+                setLoading(false);
+            });
         }, 300),
         [getEndpointsIlx, elasticSearch]
     );
 
     const addTermRequest = useCallback(async (group, term) => {
-        const token = localStorage.getItem("token")
-        const groupName = user?.groupname || group
-        await addTerm(groupName,  API_CONFIG.SCICRUNCH_KEY, token, term).then((response) => {
-            setNewTermId(response.term.id.split("/").pop())
-        })
-            .catch((error) => {
-                console.log("Error ", error)
-            });
-    }, [user]);
+        const token = localStorage.getItem("token");
+        const groupName = user?.groupname || group;
+        const body = {
+          'rdf-type': 'owl:Class',
+          label: term.label,
+          exact: term.synonyms,
+        };
+      
+        try {
+          const response = await createNewEntity({ group: groupName, data: body, session: token });
+          setAddTermResponse(response);
+          setNewTermId(response.term.id.split("/").pop());
+        } catch (error) {
+            setAddTermResponse(error.response);
+        }
+      }, [user]);      
 
     const handleChangeTabs = (_, newValue) => setTabValue(newValue);
     const handleSidebarToggle = () => setOpenSidebar(!openSidebar);
@@ -195,7 +192,7 @@ const AddNewTermDialogContent = ({ activeStep, areMatchesChecked, onMatchesChang
     const formattedNewTermId = formatIdText(newTermId);
 
 
-    const statusProps = getAddTermStatusProps(responseStatus, termValue);
+    const statusProps = getAddTermStatusProps(addTermResponse, termValue);
 
     return (
         <>

--- a/src/components/TermEditor/ExistingIdsSearch.tsx
+++ b/src/components/TermEditor/ExistingIdsSearch.tsx
@@ -19,7 +19,8 @@ const ExistingIdsSearch = ({ options, value, onChange, label, placeholder }) => 
         <>
             <Typography variant="body1" sx={{ fontWeight: 500, color: gray800, marginBottom: '0.75rem' }}>{label}</Typography>
             <Autocomplete
-                options={options}
+                multiple
+                options={options || []}
                 disableClearable
                 value={value}
                 onChange={onChange}

--- a/src/components/TermEditor/NewTermSidebar.jsx
+++ b/src/components/TermEditor/NewTermSidebar.jsx
@@ -47,7 +47,7 @@ export default function NewTermSidebar({ open, loading, onToggle, results, isRes
                     </Tooltip>
                 </Box>
             )}
-            {open && (
+            {(open && results )&& (
                 <Box width={1} height={1} display="flex" flexDirection="column" alignItems="center" gap={1}>
                     {isResultsEmpty ? (
                         <Box width={1} height={1} display="flex" flexDirection="column" alignItems="center" justifyContent="center" gap={2}>
@@ -60,7 +60,7 @@ export default function NewTermSidebar({ open, loading, onToggle, results, isRes
                             </Stack>
                         </Box>
                     ) : (
-                        <>{results.map((result) => (
+                        <>{results?.map((result) => (
                             <Box width={1} key={result.id} display="flex" flexDirection="column" px={1} py={1.5} gap={1}
                                 sx={{
                                     borderBottom: '1px solid #DADDDC',

--- a/src/components/TermEditor/TermDialog.jsx
+++ b/src/components/TermEditor/TermDialog.jsx
@@ -96,6 +96,7 @@ const TermDialog = ({ open, handleClose, searchTerm, forwardPredicateStep }) => 
                     areMatchesChecked={areMatchesChecked}
                     onMatchesChange={handleMatchesChange}
                     onReset={handleReset}
+                    onClose={handleCancelBtnClick}
                 />
             )}
         </CustomizedDialog>

--- a/src/components/TermEditor/termStatusProps.js
+++ b/src/components/TermEditor/termStatusProps.js
@@ -1,12 +1,14 @@
-export const getAddTermStatusProps = (responseStatus, termValue) => ({
-    statusResponse: responseStatus,
+export const getAddTermStatusProps = (response, termValue) => ({
+    statusResponse: response,
+    success : response?.status < 400,
+    error : response?.status > 400 ,
     successMessage: "Term successfully created",
     failureMessage: "Unable to create the term",
     successDescription: `Your term “${termValue.charAt(0).toUpperCase() + termValue.slice(1)}” has been added. Go to your term or add a new one.`,
     failureDescription: `Your term “${termValue.charAt(0).toUpperCase() + termValue.slice(1)}” has can’t be added. Close or try again.`,
-    actionButtonMessage: responseStatus?.success ? "Add a new term" : null,
-    isCloseButtonVisible: responseStatus?.success ? false : true,
-    isTryButtonVisible: responseStatus?.success ? false : true,
+    actionButtonMessage: response?.success ? "Add a new term" : null,
+    isCloseButtonVisible: response?.status < 400 ? false : true,
+    isTryButtonVisible: response?.status < 400 ? false : true,
 });
 
 export const getTermStatusProps = (responseStatus, termValue) => ({

--- a/src/components/common/StatusStep.jsx
+++ b/src/components/common/StatusStep.jsx
@@ -5,7 +5,7 @@ import { StatusErrorBackgroundPattern, AddedSuccessfully } from "../../Icons";
 import { vars } from "../../theme/variables";
 const { gray900, gray600 } = vars;
 
-const StatusBackground = ({ responseStatus }) => (
+const StatusBackground = ({ success }) => (
     <Box
         sx={{
             height: '17.875rem',
@@ -17,12 +17,12 @@ const StatusBackground = ({ responseStatus }) => (
             zIndex: 1,
         }}
     >
-        {responseStatus?.success ? <AddedSuccessfully /> : <StatusErrorBackgroundPattern />}
+        {success ? <AddedSuccessfully /> : <StatusErrorBackgroundPattern />}
     </Box>
 );
 
 StatusBackground.propTypes = {
-    responseStatus: PropTypes.object,
+    success: PropTypes.bool,
 };
 
 const StatusMessage = ({ message, description, additionalInfo }) => (
@@ -38,7 +38,7 @@ const StatusMessage = ({ message, description, additionalInfo }) => (
         <Typography mb='1.25rem' color={gray600} fontSize='1rem' sx={{ textAlign: "center", maxWidth: "22rem" }}>
             {description}
         </Typography>
-        <Typography mb="2rem">{additionalInfo}</Typography>
+        {typeof additionalInfo === 'string' ? <Typography mb="2rem">{additionalInfo}</Typography> : null}
     </Box>
 );
 
@@ -80,7 +80,7 @@ ActionButtons.propTypes = {
 
 const StatusStep = ({ statusProps, onAction, onTryAgain, onClose, actionButtonStartIcon, additionalInfo }) => {
     const {
-        statusResponse,
+        success,
         successMessage,
         successDescription,
         failureMessage,
@@ -90,17 +90,13 @@ const StatusStep = ({ statusProps, onAction, onTryAgain, onClose, actionButtonSt
         isCloseButtonVisible,
     } = statusProps;
 
-    const message = statusResponse?.success
+    const message = success
         ? successMessage
-        : statusResponse?.error
-            ? failureMessage
-            : '';
+        : failureMessage
 
-    const description = statusResponse?.success
+    const description = success
         ? successDescription
-        : statusResponse?.error
-            ? failureDescription
-            : '';
+        : failureDescription
 
     return (
         <Box
@@ -111,7 +107,7 @@ const StatusStep = ({ statusProps, onAction, onTryAgain, onClose, actionButtonSt
             height='100%'
             position='relative'
         >
-            <StatusBackground responseStatus={statusResponse} />
+            <StatusBackground success={success} />
             <Box
                 display='flex'
                 flexDirection='column'

--- a/src/config.js
+++ b/src/config.js
@@ -29,6 +29,7 @@ export const API_CONFIG = {
         NEWUSER_ORCID: "/u/ops/orcid-new",
         USER_SETTINGS: "/priv/settings",
         CREATE_NEW_ORGANIZATION: "/priv/org-new",
+        CREATE_NEW_ENTITY: "/priv/entity-new",
         GET_ORGANIZATIONS: "/priv/role-other",
         LOGOUT: "/priv/logout",
     },

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,6 +8,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CookiesProvider } from 'react-cookie';
 const queryClient = new QueryClient();
 
+worker.start();
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <CookiesProvider>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,8 +8,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CookiesProvider } from 'react-cookie';
 const queryClient = new QueryClient();
 
-worker.start();
-
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <CookiesProvider>

--- a/vite.config.js
+++ b/vite.config.js
@@ -38,7 +38,7 @@ export default defineConfig({
           });
         },
       },
-      '^/([^/]+)/priv/(.*)': {
+      '^/priv/.*': {
         target: "https://uri.olympiangods.org",
         secure: false,
         changeOrigin: true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -38,7 +38,7 @@ export default defineConfig({
           });
         },
       },
-      '^/priv/.*': {
+      '^/([^/]+)/priv/(.*)': {
         target: "https://uri.olympiangods.org",
         secure: false,
         changeOrigin: true,
@@ -59,7 +59,7 @@ export default defineConfig({
             console.log('Received Response from the Target:', proxyRes.statusCode, req.url);
           });
         },
-      },
+      }
     },
   },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -69,7 +69,7 @@ export default defineConfig({
               // Inject the location into a custom header we can use in Axios
               res.setHeader('X-Redirect-Location', location);
             }
-            
+
             // Required for credentialed CORS
             const origin = req.headers.origin;
             if (origin) {
@@ -81,12 +81,12 @@ export default defineConfig({
                 
         },
       },
-      '^/[^/]+/tmp_.*\\.html$': {
+      '^/[^/]+/(tmp|ilx)_.*\\.(html|ttl|jsonld|n3|owl|csv)$': {
         target: 'https://uri.olympiangods.org',
         changeOrigin: true,
         secure: false,
         rewrite: path => path, // Keep full path intact
-        configure: (proxy, _options) => {
+        configure: (proxy) => {
           proxy.on('proxyRes', (proxyRes, req, res) => {
             const origin = req.headers.origin;
             if (origin) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -42,6 +42,9 @@ export default defineConfig({
         target: "https://uri.olympiangods.org",
         secure: false,
         changeOrigin: true,
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
         configure: (proxy, _options) => {
           console.log(_options);
           proxy.on('error', (err, _req, _res) => {
@@ -51,13 +54,24 @@ export default defineConfig({
           });
           proxy.on('proxyReq', (proxyReq, req, _res) => {
             console.log('Sending Request to the Target:', req.method, req.url);
+            console.log('Headers sent to backend:', proxyReq.getHeaders());
             console.log('Response:', _res);
             console.log('Request:', proxyReq);
+            // Forward cookies manually if needed
+            if (req.headers.cookie) {
+              proxyReq.setHeader('cookie', req.headers.cookie);
+            }
           });
-          proxy.on('proxyRes', (proxyRes, req, _res) => {
-            console.log('Received response', _res);
-            console.log('Received Response from the Target:', proxyRes.statusCode, req.url);
+          proxy.on('proxyRes', (proxyRes, req, res) => {
+            const location = proxyRes.headers['location'];
+            console.log('Received location', location);
+          
+            if (proxyRes.statusCode === 303 && location) {
+              res.setHeader('X-Redirect-Location', location);
+              res.setHeader('Access-Control-Expose-Headers', 'X-Redirect-Location');
+            }
           });
+                
         },
       }
     },


### PR DESCRIPTION

**Summary**
This PR allows doing a POST on olympian gods to submit a new entity. User must be login. The term is sent as a POST to the Olympian Gods endpoint /priv/entity-new, which is then follow with a response with redirect location. This PR also adds support for following 303 redirects returned during term creation. Axios intercepts these responses and fetches the redirected resource (e.g. .html, .jsonld, .ttl) through the Vite proxy to avoid CORS errors. Term IDs like TMP:000000057 or ILX:0622415 are extracted and displayed in the UI as part of the Add Term flow.

**🔧 Changed Files Related to POST**
```
mock/mutator/customClient.ts – Axios interceptor for 303 + redirect follow
vite.config.js – Proxy for dynamic tmp_* and ilx_* files with multiple extensions
src/api/endpoints/apiService.ts – createNewEntity() handles redirects and ID parsing
src/components/TermEditor/AddNewTermDialogContent.jsx – Integrated with new logic, shows formatted term ID
src/components/common/StatusStep.jsx + termStatusProps.js – Updated success/error UI handling
```

**🔧 Other Changed Files**
→ All updated to call getMatchTerms() with correct group and search term. Also a fix to retrieving raw data without using orval
```
src/components/SingleTermView/OverView/CustomizedTable.jsx
src/components/SingleTermView/OverView/OverView.jsx
src/components/SingleTermView/OverView/RawDataViewer.jsx
src/components/SingleTermView/OverView/PredicateGroupInput.jsx
src/components/SingleTermView/RequestMergeChanges.jsx
```

