### PR TITLE
ILEX-118 Button to create an organization should be visible only for logged in users.

### DIFF
--- a/src/components/organizations/index.jsx
+++ b/src/components/organizations/index.jsx
@@ -44,7 +44,7 @@ const Organizations = () => {
         <Typography fontSize='1.5rem' color={gray700} fontWeight={600} mb='1.5rem'>
           {organizations?.length} Organizations
         </Typography>
-        <Button type="string" startIcon={<GroupAddOutlinedIcon />} onClick={handleCreateOrganization}>Create a new organization</Button>
+        {Object.keys(user).length !== 0 && <Button type="string" startIcon={<GroupAddOutlinedIcon />} onClick={handleCreateOrganization}>Create a new organization</Button>}
       </Stack>
       <OrganizationsList organizations={organizations} />
       {message && (


### PR DESCRIPTION
Issue [#ILEX-118](https://metacell.atlassian.net/browse/ILEX-118)
Problem: Button to create an organization should be visible only for logged in users.
Solution: 
1. Use user constant to check whether we show button to create organization

Result: 

https://github.com/user-attachments/assets/65f1ab04-7a59-4c79-bd49-87066f5ee447

