### PR TITLE
#125 - Tech debt, Change html parsing from the post ontology flow 

### DIFF
--- a/src/api/endpoints/apiService.ts
+++ b/src/api/endpoints/apiService.ts
@@ -141,49 +141,61 @@ export const createNewOntology = async ({
   const endpoint = `/${groupname}/ontologies/uris/${ontologyName}/spec`;
 
   const data = {
-    title : title,
-    subjects : subjects,
+    title: title,
+    subjects: subjects,
   };
 
   const headers = {
     'Content-Type': 'application/json',
-    'Authorization': `Bearer ${token}`
+    'Authorization': `Bearer ${token}`,
   };
 
   try {
-    const postResponse = await createPostRequest<any, any>(endpoint, headers)(data);
+    // Use fetch directly for manual redirect handling
+    const postResponse = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(data),
+      redirect: 'manual', // let us handle the 303 ourselves
+    });
 
-    // If the POST creates a new location, try fetching it (simulate follow-up GETs from the test)
-    if (postResponse?.location) {
-      const getResponse = await fetch(postResponse.location, {
-        headers: {
-          Accept: 'application/json',
-        },
-      });
+    if (postResponse.status === 303) {
+      const location = postResponse.headers.get('Location');
+      if (location) {
+        // Fetch the ontology resource at the redirected location (JSON)
+        const getResponse = await fetch(location, {
+          headers: {
+            Accept: 'application/json',
+            'Authorization': `Bearer ${token}`,
+          },
+        });
 
-      // Optionally fetch HTML if needed (like the .html equivalent in the Python test)
-      const htmlResponse = await fetch(endpoint, {
-        headers: {
-          Accept: 'text/html',
-        },
-      });
+        // Optionally, also fetch the HTML representation
+        const htmlResponse = await fetch(location, {
+          headers: {
+            Accept: 'text/html',
+            'Authorization': `Bearer ${token}`,
+          },
+        });
 
-      return {
-        created: true,
-        data: postResponse,
-        jsonResponse: await getResponse.json(),
-        htmlAvailable: htmlResponse.ok,
-      };
+        return {
+          created: true,
+          location,
+          jsonResponse: getResponse.ok ? await getResponse.json() : null,
+          htmlAvailable: htmlResponse.ok,
+        };
+      } else {
+        throw new Error('No Location header in 303 response');
+      }
+    } else {
+      // If not a 303, handle as error or unexpected case
+      const errorBody = await postResponse.text();
+      throw new Error(`Unexpected response status: ${postResponse.status} - ${errorBody}`);
     }
-
-    return {
-      created: true,
-      data: postResponse,
-    };
   } catch (error: any) {
     return {
       created: false,
-      error: error?.response?.data || error.message,
+      error: error?.message ?? String(error),
     };
   }
 };

--- a/src/api/endpoints/apiService.ts
+++ b/src/api/endpoints/apiService.ts
@@ -168,12 +168,7 @@ export const createNewOntology = async ({
       const getResponse = await fetch(olympianRedirectLocation, { headers: { Authorization: `Bearer ${token}` } });
       const jsonResponse = await getResponse.json();
 
-      let newOntologyID = null;
-      jsonResponse?.["@graph"]?.forEach((object) => {
-          if (object["@type"] === "owl:Ontology") {
-            newOntologyID = object["@id"];
-          }
-      });
+      const newOntologyID = jsonResponse?.["@graph"]?.find((object) => object["@type"] === "owl:Ontology")?.["@id"] || null;
       
       return {
         created: true,

--- a/src/api/endpoints/apiService.ts
+++ b/src/api/endpoints/apiService.ts
@@ -1,5 +1,6 @@
 import { createPostRequest, createGetRequest } from "./apiActions";
 import { API_CONFIG } from "../../config";
+import { Term } from "../../model/frontend/terms";
 
 export interface LoginRequest {
   username: string
@@ -151,51 +152,55 @@ export const createNewOntology = async ({
   };
 
   try {
-    // Use fetch directly for manual redirect handling
     const postResponse = await fetch(endpoint, {
       method: 'POST',
       headers,
+      credentials: "include",
       body: JSON.stringify(data),
-      redirect: 'manual', // let us handle the 303 ourselves
+      redirect: 'manual',
     });
 
-    if (postResponse.status === 303) {
-      const location = postResponse.headers.get('Location');
-      if (location) {
-        // Fetch the ontology resource at the redirected location (JSON)
-        const getResponse = await fetch(location, {
-          headers: {
-            Accept: 'application/json',
-            'Authorization': `Bearer ${token}`,
-          },
-        });
+    // Check for custom redirect header (all lowercase in fetch)
+    const redirectLocation = postResponse.headers.get('x-redirect-location');
 
-        // Optionally, also fetch the HTML representation
-        const htmlResponse = await fetch(location, {
-          headers: {
-            Accept: 'text/html',
-            'Authorization': `Bearer ${token}`,
-          },
-        });
+    if (redirectLocation) {
+      const olympianRedirectLocation = redirectLocation.replace('http://uri.interlex.org','').replace('html', 'jsonld')
 
-        return {
-          created: true,
-          location,
-          jsonResponse: getResponse.ok ? await getResponse.json() : null,
-          htmlAvailable: htmlResponse.ok,
-        };
-      } else {
-        throw new Error('No Location header in 303 response');
-      }
-    } else {
-      // If not a 303, handle as error or unexpected case
-      const errorBody = await postResponse.text();
-      throw new Error(`Unexpected response status: ${postResponse.status} - ${errorBody}`);
+      const getResponse = await fetch(olympianRedirectLocation, { headers: { Authorization: `Bearer ${token}` } });
+      const jsonResponse = await getResponse.json();
+
+      let newOntologyID = null;
+      jsonResponse?.["@graph"]?.forEach((object) => {
+          if (object["@type"] === "owl:Ontology") {
+            newOntologyID = object["@id"];
+          }
+      });
+      
+      return {
+        created: true,
+        location: olympianRedirectLocation,
+        newOntologyID: newOntologyID
+      };
     }
+
+    // Try to parse the response as JSON (if present)
+    let jsonResponse: any = null;
+    try {
+      jsonResponse = await postResponse.json();
+    } catch (e) {
+      // No JSON body, ignore
+    }
+
+    return {
+      created: postResponse.ok,
+      location: endpoint,
+      jsonResponse,
+    };
   } catch (error: any) {
+    let errMsg = error?.message ?? String(error);
     return {
       created: false,
-      error: error?.message ?? String(error),
+      error: errMsg,
     };
   }
 };

--- a/src/api/endpoints/apiService.ts
+++ b/src/api/endpoints/apiService.ts
@@ -1,6 +1,5 @@
 import { createPostRequest, createGetRequest } from "./apiActions";
 import { API_CONFIG } from "../../config";
-import { Term } from "../../model/frontend/terms";
 
 export interface LoginRequest {
   username: string
@@ -164,7 +163,7 @@ export const createNewOntology = async ({
     const redirectLocation = postResponse.headers.get('x-redirect-location');
 
     if (redirectLocation) {
-      const olympianRedirectLocation = redirectLocation.replace('http://uri.interlex.org','').replace('html', 'jsonld')
+      const olympianRedirectLocation = redirectLocation.replace('http://uri.interlex.org','').replace(/\.html$/, '.jsonld');
 
       const getResponse = await fetch(olympianRedirectLocation, { headers: { Authorization: `Bearer ${token}` } });
       const jsonResponse = await getResponse.json();

--- a/src/components/SingleOrganization/AddNewOntologyDialog.jsx
+++ b/src/components/SingleOrganization/AddNewOntologyDialog.jsx
@@ -76,12 +76,8 @@ const AddNewOntologyDialog = ({ open, handleClose }) => {
         if (result.created) {
           console.log('Ontology details:', result.data);
       
-          if (result.jsonResponse) {
-            console.log('Retrieved JSON:', result.jsonResponse);
-          }
-      
-          if (result.htmlAvailable !== undefined) {
-            console.log('HTML version available:', result.htmlAvailable);
+          if (result.newOntologyID) {
+            console.log('Created new Ontology:', result.newOntologyID);
           }
         } else {
             ontologyResponseMessage = "Failed to create ontology"

--- a/src/components/SingleOrganization/AddNewOntologyDialog.jsx
+++ b/src/components/SingleOrganization/AddNewOntologyDialog.jsx
@@ -73,13 +73,7 @@ const AddNewOntologyDialog = ({ open, handleClose }) => {
 
         let ontologyResponseMessage = "Ontology created successfully!"
         
-        if (result.created) {
-          console.log('Ontology details:', result.data);
-      
-          if (result.newOntologyID) {
-            console.log('Created new Ontology:', result.newOntologyID);
-          }
-        } else {
+        if (!result.created) {
             ontologyResponseMessage = "Failed to create ontology"
             console.error('❌ Failed to create ontology:', result.error);
         }

--- a/vite.config.js
+++ b/vite.config.js
@@ -67,7 +67,6 @@ export default defineConfig({
             if (proxyRes.statusCode === 303 && location) {
               // Prevent browser from seeing the actual Location
               delete proxyRes.headers['location'];
-              console.log('Status code 303 ', proxyRes);
               // Inject the location into a custom header we can use in Axios
               res.setHeader('X-Redirect-Location', location);
             }
@@ -106,9 +105,7 @@ export default defineConfig({
         configure: (proxy) => {
           proxy.on('proxyRes', (proxyRes, req, res) => {
             const origin = req.headers.origin;
-            console.log('Received response for new ontology', res);
             if (origin) {
-              console.log('Setting CORS header for origin:', origin);
               res.setHeader('Access-Control-Allow-Origin', origin);
             }
             res.setHeader('Access-Control-Allow-Credentials', 'true');
@@ -122,18 +119,13 @@ export default defineConfig({
         rewrite: path => path, // Keep full path
         configure: (proxy) => {
           proxy.on('proxyReq', (proxyReq, req) => {
-            console.log('Proxying ontology spec request:', req.method, req.url);
-            console.log('Headers:', proxyReq.getHeaders());
             if (req.headers.authorization) {
               proxyReq.setHeader('Authorization', req.headers.authorization);
             }
           });
       
           proxy.on('proxyRes', (proxyRes, req, res) => {
-            console.log('Received response', res);
-            console.log('Received Response from the Target:', proxyRes.statusCode, req.url);
             const location = proxyRes.headers['location'];
-            console.log('Received location', location);
           
             if (proxyRes.statusCode === 303 && location) {
               delete proxyRes.headers['location'];

--- a/vite.config.js
+++ b/vite.config.js
@@ -67,7 +67,7 @@ export default defineConfig({
             if (proxyRes.statusCode === 303 && location) {
               // Prevent browser from seeing the actual Location
               delete proxyRes.headers['location'];
-          
+              console.log('Status code 303 ', proxyRes);
               // Inject the location into a custom header we can use in Axios
               res.setHeader('X-Redirect-Location', location);
             }
@@ -98,6 +98,23 @@ export default defineConfig({
           });
         },
       },
+      '^/[^/]+/ontologies/uris/.*\\.(html|jsonld)$': {
+        target: 'https://uri.olympiangods.org',
+        changeOrigin: true,
+        secure: false,
+        rewrite: path => path, // Keep the full path
+        configure: (proxy) => {
+          proxy.on('proxyRes', (proxyRes, req, res) => {
+            const origin = req.headers.origin;
+            console.log('Received response for new ontology', res);
+            if (origin) {
+              console.log('Setting CORS header for origin:', origin);
+              res.setHeader('Access-Control-Allow-Origin', origin);
+            }
+            res.setHeader('Access-Control-Allow-Credentials', 'true');
+          });
+        },
+      },
       '^/[^/]+/ontologies/uris/.*/spec': {
         target: 'https://uri.olympiangods.org',
         changeOrigin: true,
@@ -119,11 +136,15 @@ export default defineConfig({
             console.log('Received location', location);
           
             if (proxyRes.statusCode === 303 && location) {
-              // Prevent browser from seeing the actual Location
               delete proxyRes.headers['location'];
-          
-              // Inject the location into a custom header we can use in Axios
+              res.statusCode = 200; // Prevent browser redirect
               res.setHeader('X-Redirect-Location', location);
+              res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+              res.setHeader('Access-Control-Allow-Credentials', 'true');
+              res.setHeader('Access-Control-Expose-Headers', 'X-Redirect-Location');
+              // Send a JSON body (for fetch, etc.)
+              res.end(JSON.stringify({ location }));
+              return;
             }
 
             // Required for credentialed CORS


### PR DESCRIPTION
Changes create new ontology behavior, first POST new ontology. Then once we get back the redirect location of the new term, we do a GET using the endpoint and then we extract json data from there. Before we do the GET though, we need to clean up the URI as we get back 'http://uri.interlex.org/dariodippi/ontologies/uris/test_test_pbt46efr.html' , but we need 'http://uri.olympiangods.orgdariodippi/ontologies/uris/test_test_pbt46efr.jsonld'

As commented on JIRA:

Works now, and a PR was created. However, a couple of issues:

The redirect location we are getting back is not from olympiangods but from uri.interlex.org, and the jsonld is missing the ID in the response. So far our only option seems to extract from URL itself, see new ontology below for newly created: test_099_sbwulriy.jsonld:

```
{
  "@context": {
    "brick": "https://brickschema.org/schema/Brick#",
    "csvw": "http://www.w3.org/ns/csvw#",
    "dc": "http://purl.org/dc/elements/1.1/",
    "dcam": "http://purl.org/dc/dcam/",
    "dcat": "http://www.w3.org/ns/dcat#",
    "dcmitype": "http://purl.org/dc/dcmitype/",
    "dcterms": "http://purl.org/dc/terms/",
    "doap": "http://usefulinc.com/ns/doap#",
    "foaf": "http://xmlns.com/foaf/0.1/",
    "geo": "http://www.opengis.net/ont/geosparql#",
    "odrl": "http://www.w3.org/ns/odrl/2/",
    "org": "http://www.w3.org/ns/org#",
    "owl": "http://www.w3.org/2002/07/owl#",
    "prof": "http://www.w3.org/ns/dx/prof/",
    "prov": "http://www.w3.org/ns/prov#",
    "qb": "http://purl.org/linked-data/cube#",
    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
    "schema": "https://schema.org/",
    "sh": "http://www.w3.org/ns/shacl#",
    "skos": "http://www.w3.org/2004/02/skos/core#",
    "sosa": "http://www.w3.org/ns/sosa/",
    "ssn": "http://www.w3.org/ns/ssn/",
    "time": "http://www.w3.org/2006/time#",
    "vann": "http://purl.org/vocab/vann/",
    "void": "http://rdfs.org/ns/void#",
    "wgs": "https://www.w3.org/2003/01/geo/wgs84_pos#",
    "xsd": "http://www.w3.org/2001/XMLSchema#"
  },
  "@graph": [
    {
      "@id": "http://purl.obolibrary.org/obo/BFO_0000001",
      "@type": "owl:Class",
      "http://purl.obolibrary.org/obo/BFO_0000179": "entity",
      "http://purl.obolibrary.org/obo/BFO_0000180": "Entity",
      "http://purl.obolibrary.org/obo/IAO_0000112": [
        {
          "@language": "en",
          "@value": "Julius Caesar"
        },
        {
          "@language": "en",
          "@value": "the Second World War"
        },
        {
          "@language": "en",
          "@value": "Verdi’s Requiem"
        },
        {
          "@language": "en",
          "@value": "your body mass index"
        }
      ],
      "http://purl.obolibrary.org/obo/IAO_0000116": [
        {
          "@language": "en",
          "@value": "BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81"
        },
        {
          "@language": "en",
          "@value": "Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"
        }
      ],
      "http://purl.obolibrary.org/obo/IAO_0000600": {
        "@language": "en",
        "@value": "An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])"
      },
      "rdfs:isDefinedBy": {
        "@id": "http://purl.obolibrary.org/obo/bfo.owl"
      },
      "rdfs:label": {
        "@language": "en",
        "@value": "entity"
      },
      "rdfs:subClassOf": {
        "@id": "owl:Thing"
      }
    },
    {
      "@id": "http://purl.obolibrary.org/obo/IAO_0000001",
      "@type": "owl:Class",
      "http://purl.obolibrary.org/obo/IAO_0000111": {
        "@language": "en",
        "@value": "conditional specification"
      },
      "http://purl.obolibrary.org/obo/IAO_0000114": {
        "@id": "http://purl.obolibrary.org/obo/IAO_0000120"
      },
      "http://purl.obolibrary.org/obo/IAO_0000115": {
        "@language": "en",
        "@value": "A directive information entity that specifies what should happen if the trigger condition is fulfilled."
      },
      "http://purl.obolibrary.org/obo/IAO_0000117": {
        "@language": "en",
        "@value": "PlanAndPlannedProcess Branch"
      },
      "http://purl.obolibrary.org/obo/IAO_0000119": [
        {
          "@language": "en",
          "@value": "OBI_0000349"
        },
        {
          "@language": "en",
          "@value": "OBI branch derived"
        }
      ],
      "rdfs:label": {
        "@language": "en",
        "@value": "conditional specification"
      },
      "rdfs:subClassOf": {
        "@id": "http://purl.obolibrary.org/obo/IAO_0000033"
      }
    },
    {
      "@id": "http://uri.interlex.org/dariodippi/ontologies/None_None",
      "@type": "owl:Ontology",
      "http://purl.obolibrary.org/obo/IAO_0000136": {
        "@id": "http://uri.interlex.org/dariodippi/None_None"
      },
      "owl:versionIRI": {
        "@id": "http://uri.interlex.org/dariodippi/ontologies/None_None/version/1751425211/None_None"
      },
      "owl:versionInfo": "2025-07-02T03:00:11,248255Z",
      "rdfs:comment": "InterLex single term result for dariodippi/None_None at 2025-07-02T03:00:11,248255Z"
    }
  ]
}
```