### PR TITLE
ILEX-129 Refactor getSelectedTermLabel to follow the same pattern used for other requests

### DIFF
--- a/src/api/endpoints/apiService.ts
+++ b/src/api/endpoints/apiService.ts
@@ -1,5 +1,6 @@
 import { createPostRequest, createGetRequest } from "./apiActions";
 import { API_CONFIG } from "../../config";
+import termParser from "../../parsers/termParser";
 
 export interface LoginRequest {
   username: string
@@ -28,9 +29,11 @@ interface JsonLdResponse {
   '@graph'?: GraphNode[];
 }
 
-export const login = createPostRequest<any, LoginRequest>(API_CONFIG.REAL_API.SIGNIN, {"Content-Type": "application/x-www-form-urlencoded"})
+const BASE_EXTENSION = "jsonld";
 
-export const register = createPostRequest<any, RegisterRequest>(API_CONFIG.REAL_API.NEWUSER_ILX, {"Content-Type": "application/x-www-form-urlencoded"})
+export const login = createPostRequest<any, LoginRequest>(API_CONFIG.REAL_API.SIGNIN, { "Content-Type": "application/x-www-form-urlencoded" })
+
+export const register = createPostRequest<any, RegisterRequest>(API_CONFIG.REAL_API.NEWUSER_ILX, { "Content-Type": "application/x-www-form-urlencoded" })
 
 
 export const getUserSettings = (group: string) => {
@@ -40,7 +43,7 @@ export const getUserSettings = (group: string) => {
 
 export const createNewOrganization = ({ group, data }: { group: string, data: any }) => {
   const endpoint = `/${group}${API_CONFIG.REAL_API.CREATE_NEW_ORGANIZATION}`;
-  return createPostRequest<any, any>(endpoint, { "Content-Type" : "application/json" })(data);
+  return createPostRequest<any, any>(endpoint, { "Content-Type": "application/json" })(data);
 };
 
 export const getOrganizations = (group: string) => {
@@ -55,11 +58,9 @@ export const userLogout = (group: string) => {
 
 export const getSelectedTermLabel = async (searchTerm: string): Promise<string | undefined> => {
   try {
-    const res = await fetch(`https://uri.olympiangods.org/base/${searchTerm}.jsonld`);
-    if (!res.ok) throw new Error(`Response status: ${res.status}`);
+    const response = await createGetRequest<JsonLdResponse, any>(`/base/${searchTerm}.jsonld`)();
 
-    const data: JsonLdResponse = await res.json();
-    const label = data['@graph']?.[0]?.['rdfs:label'];
+    const label = response['@graph']?.[0]?.['rdfs:label'];
 
     const getLabelValue = (label: LabelType): string => {
       if (typeof label === 'string') return label;
@@ -84,7 +85,7 @@ export const createNewEntity = async ({ group, data, session }: { group: string;
     const endpoint = `/${group}${API_CONFIG.REAL_API.CREATE_NEW_ENTITY}`;
     const response = await createPostRequest<any, any>(
       endpoint,
-      { "Content-Type" : "application/x-www-form-urlencoded" }
+      { "Content-Type": "application/x-www-form-urlencoded" }
     )(data);
 
     // If the response is HTML (a string), extract TMP ID
@@ -141,8 +142,8 @@ export const createNewOntology = async ({
   const endpoint = `/${groupname}/ontologies/uris/${ontologyName}/spec`;
 
   const data = {
-    title : title,
-    subjects : subjects,
+    title: title,
+    subjects: subjects,
   };
 
   const headers = {
@@ -190,10 +191,46 @@ export const createNewOntology = async ({
 
 export const getNewTokenApi = ({ groupname, data }: { groupname: string, data: any }) => {
   const endpoint = `/${groupname}${API_CONFIG.REAL_API.API_NEW_TOKEN}`;
-  return createPostRequest<any, any>(endpoint, { "Content-Type" : "application/json" })(data);
+  return createPostRequest<any, any>(endpoint, { "Content-Type": "application/json" })(data);
 };
 
 export const retrieveTokenApi = ({ groupname }: { groupname: string }) => {
   const endpoint = `/${groupname}${API_CONFIG.REAL_API.API_RETRIEVE_TOKEN}`;
   return createGetRequest<any, any>(endpoint, "application/json")();
+};
+
+export const getMatchTerms = async (group: string, term: string, filters = {}) => {
+  try {
+    const response = await createGetRequest<any, any>(`/${group}/${term}.${BASE_EXTENSION}`, "application/json")();
+    return termParser(response, term);
+  } catch (err: any) {
+    console.error(err.message);
+    return undefined;
+  }
+};
+
+export const getRawData = async (group: string, termID: string, format: string) => {
+  try {
+    const response = await createGetRequest<any, any>(`/${group}/${termID}.${format}`, "application/json")();
+    return response;
+  } catch (err: any) {
+    console.error(err.message);
+    return undefined;
+  }
+};
+
+export const getVariants = async (group: string, term: string) => {
+  return createGetRequest<any, any>(`/${group}/variants/${term}`, "application/json")();
+};
+
+export const getVersions = async (group: string, term: string) => {
+  return createGetRequest<any, any>(`/${group}/versions/${term}`, "application/json")();
+};
+
+export const getTermDiscussions = async (group: string, variantID: string) => {
+  return createGetRequest<any, any>(`/${group}/discussions/term/${variantID}`, "application/json")();
+};
+
+export const getVariant = (group: string, term: string) => {
+  return createGetRequest<any, any>(`/${group}/variant/${term}`, "application/json")();  
 };

--- a/src/components/SingleTermView/Discussion/index.jsx
+++ b/src/components/SingleTermView/Discussion/index.jsx
@@ -4,7 +4,7 @@ import TimeLine from "./TimeLine";
 import { vars } from "../../../theme/variables";
 import { useState, useRef, useEffect } from "react";
 import CommentEditor from "./CommentEditor";
-import { getTermDiscussions } from "../../../api/endpoints";
+import { getTermDiscussions } from "../../../api/endpoints/apiService";
 
 const { gray25, gray200, gray700 } = vars;
 

--- a/src/components/SingleTermView/History/HistoryPanel.jsx
+++ b/src/components/SingleTermView/History/HistoryPanel.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import HistoryItem from "./HistoryItem";
 import { Box, List } from "@mui/material";
-import { getVersions } from './../../../api/endpoints';
+import { getVersions } from "../../../api/endpoints/apiService";
 
 import { vars } from "../../../theme/variables";
 const { gray50 } = vars;

--- a/src/components/SingleTermView/OverView/OverView.jsx
+++ b/src/components/SingleTermView/OverView/OverView.jsx
@@ -10,7 +10,7 @@ import Hierarchy from "./Hierarchy";
 import Predicates from "./Predicates";
 import RawDataViewer from "./RawDataViewer";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { getMatchTerms, getRawData } from "../../../api/endpoints";
+import { getMatchTerms, getRawData } from "../../../api/endpoints/apiService";
 
 const OverView = ({ searchTerm, isCodeViewVisible, selectedDataFormat }) => {
   const [data, setData] = useState(null);

--- a/src/components/SingleTermView/OverView/RawDataViewer.jsx
+++ b/src/components/SingleTermView/OverView/RawDataViewer.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { useState, useEffect } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { a11yLight } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-import { getRawData } from "../../../api/endpoints";
+import { getRawData } from '../../../api/endpoints/apiService';
 
 import { vars } from '../../../theme/variables';
 const { gray25, gray200, gray500 } = vars;

--- a/src/components/SingleTermView/RequestMergeChanges.jsx
+++ b/src/components/SingleTermView/RequestMergeChanges.jsx
@@ -4,12 +4,10 @@ import { EditNoteIcon } from "../../Icons";
 import { Box, Button } from "@mui/material";
 import MergePanel from "./MergePanel/MergePanel";
 import StatusDialog from "../common/StatusDialog";
-import { getMatchTerms } from "../../api/endpoints";
+import { getMatchTerms, getVariant } from '../../api/endpoints/apiService';
 import { useState, useEffect, useCallback } from "react";
 import CustomizedDialog from "../common/CustomizedDialog";
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
-import { getVariant } from "../../api/endpoints/swaggerMockMissingEndpoints";
-
 
 const HeaderRightSideContent = ({ handleClose, handleSubmit }) => {
     return (

--- a/src/components/SingleTermView/Variants/VariantsPanel.jsx
+++ b/src/components/SingleTermView/Variants/VariantsPanel.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '@mui/material';
 import VariantsTable from './VariantsTable';
-import { getVariants  } from '../../../api/endpoints';
+import { getVariants } from '../../../api/endpoints/apiService';
 
 const rows = [
     {
@@ -84,7 +84,7 @@ const VariantsPanel = () => {
 
     return (
         <Box flexGrow={1} p="2.5rem 5rem" overflow='auto'>
-            <VariantsTable rows={rows} headCells={headCells} />
+            <VariantsTable rows={variants} headCells={headCells} />
         </Box>
     )
 }

--- a/src/components/SingleTermView/Variants/VariantsPanel.jsx
+++ b/src/components/SingleTermView/Variants/VariantsPanel.jsx
@@ -4,64 +4,6 @@ import { Box } from '@mui/material';
 import VariantsTable from './VariantsTable';
 import { getVariants } from '../../../api/endpoints/apiService';
 
-const rows = [
-    {
-        id: 1, organization: 'Cupcake',
-        description: "The central nervous system (CNS) is the part of the nervous system which includes the brain, spinal cord, and nerve cell layer of the retina. In animals with bilateral symmetry, it is a topographic division that is a condensation of the nervous system in the longitudinal plane, lying on or near the median plane. For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Active', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    },
-    {
-        id: 2, organization: 'Donut',
-        description: "The central nervous system (CNS) is the part of the nervous system which includes the brain, spinal cord, and nerve cell layer of the retina. In animals with bilateral symmetry, it is a topographic division that is a condensation of the nervous system in the longitudinal plane, lying on or near the median plane. For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Active', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    },
-    {
-        id: 3, organization: 'Eclair',
-        description: "The central nervous system (CNS) is the part of the nervous system which includes the brain, spinal cord, and nerve cell layer of the retina. In animals with bilateral symmetry, it is a topographic division that is a condensation of the nervous system in the longitudinal plane, lying on or near the median plane. For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Inactive', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    },
-    {
-        id: 4, organization: 'Frozen yoghurt',
-        description: "The central nervous system (CNS) is the part of the nervous system which includes the brain, spinal cord, and nerve cell layer of the retina. In animals with bilateral symmetry, it is a topographic division that is a condensation of the nervous system in the longitudinal plane, lying on or near the median plane. For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Active', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    },
-    {
-        id: 5, organization: 'Gingerbread',
-        description: "The central nervous system (CNS) is the part of the nervous system which includes the brain, spinal cord, and nerve cell layer of the retina. In animals with bilateral symmetry, it is a topographic division that is a condensation of the nervous system in the longitudinal plane, lying on or near the median plane. For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Deleted', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    },
-    {
-        id: 6, organization: 'Honeycomb',
-        description: "For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Active', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    },
-    {
-        id: 7, organization: 'Ice cream sandwich',
-        description: "For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Active', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    },
-    {
-        id: 8, organization: 'Jelly Bean',
-        description: "For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Active', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    },
-    {
-        id: 9, organization: 'KitKat',
-        description: "For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Active', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    },
-    {
-        id: 10, organization: 'Lollipop',
-        description: "For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Active', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    },
-    {
-        id: 11, organization: 'Marshmallow',
-        description: "For invertebrates the longitudinal division consists of one or more nerve cords, whereas for vertebrates it consists of a single, hollow, and dorsal cerebrospinal axis.In adult Echinoderms, which are radially symmetrical, a presumptive CNS is formed by a circular cord with associated radial cords. However, there is no ganglion that could be considered as brain in invertebrate When a CNS is present, its obligate companion topographic division is a peripheral nervous system.",
-        timestamp: '24 Mar 12:08 AM', status: 'Active', originated_user: 'Olivia Rhye', editing_user: 'Olivia Rhye', originated_user_email: 'olivia@untitledui.com', editing_user_email: 'olivia@untitledui.com'
-    }
-];
-
 const headCells = [
     { id: 'organization', label: 'Organization' },
     { id: 'description', label: 'Description' },
@@ -73,7 +15,6 @@ const headCells = [
 ];
 
 const VariantsPanel = () => {
-    // eslint-disable-next-line no-unused-vars
     const [variants, setVariants] = React.useState([]);
     
     React.useEffect(() => {


### PR DESCRIPTION
Issue [#ILEX-129](https://metacell.atlassian.net/browse/ILEX-129?atlOrigin=eyJpIjoiYTdhZjM0ZDk2ZjNlNDZjM2JmY2Q5ZmVkNjEyNjE2YjUiLCJwIjoiaiJ9)
Problem: Refactor getSelectedTermLabel to follow the same pattern used for other requests
Solution: 
1. Refactor api calls to use so that they will use custom instance in apiService file
