### PR TITLE
#125- Remove header with token authorization for POST ontology, not needed anymore

### DIFF
--- a/src/api/endpoints/apiService.ts
+++ b/src/api/endpoints/apiService.ts
@@ -180,8 +180,7 @@ export const createNewOntology = async ({
   };
 
   const headers = {
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${token}`,
+    'Content-Type': 'application/json'
   };
 
   try {
@@ -199,7 +198,7 @@ export const createNewOntology = async ({
     if (redirectLocation) {
       const olympianRedirectLocation = redirectLocation.replace('http://uri.interlex.org','').replace(/\.html$/, '.jsonld');
 
-      const getResponse = await fetch(olympianRedirectLocation, { headers: { Authorization: `Bearer ${token}` } });
+      const getResponse = await fetch(olympianRedirectLocation);
       const jsonResponse = await getResponse.json();
 
       const newOntologyID = jsonResponse?.["@graph"]?.find((object) => object["@type"] === "owl:Ontology")?.["@id"] || null;


### PR DESCRIPTION
Remove header with token authorization, not needed anymore after login 

<img width="1386" height="803" alt="Screenshot 2025-08-27 at 12 01 52 AM" src="https://github.com/user-attachments/assets/9f5993bd-753f-472a-8ac8-f1af4f27146a" />
