### PR TITLE
#137 - feat: add search functionality and restore selection in Hierarchy component

### DIFF
--- a/src/components/SingleTermView/OverView/Hierarchy.jsx
+++ b/src/components/SingleTermView/OverView/Hierarchy.jsx
@@ -39,6 +39,27 @@ const toIri = (idLike) => {
   return idLike;
 };
 
+// Collect all item ids that match a filter (id | label | iri)
+const collectMatchingIds = (items = [], term = "") => {
+  if (!term) return [];
+  const q = String(term).toLowerCase();
+  const out = new Set();
+  const stack = [...items];
+  while (stack.length) {
+    const node = stack.pop();
+    const id = String(node?.id ?? "");
+    const label = String(node?.label ?? "");
+    const iri = String(node?.iri ?? "");
+    if (
+      id.toLowerCase().includes(q) ||
+      label.toLowerCase().includes(q) ||
+      iri.toLowerCase().includes(q)
+    ) out.add(id);
+    if (Array.isArray(node?.children)) stack.push(...node.children);
+  }
+  return [...out];
+};
+
 const Hierarchy = ({
   options = { children: [], superclasses: [] }, // {children:[{id,label}], superclasses:[...]}
   selectedValue,                                 // { id, label }
@@ -51,20 +72,77 @@ const Hierarchy = ({
   const [type, setType] = React.useState(SUPERCLASSES); // default to superclasses
   const [currentId, setCurrentId] = React.useState(null);
 
-  // when selection or type changes, recompute which tree + currentId to show
-  React.useEffect(() => {
-    const focusIri = toIri(selectedValue?.id);
-    const items = type === CHILDREN ? treeChildren : treeSuperclasses;
-    setCurrentId(findFirstRenderedId(items, focusIri));
-  }, [selectedValue, type, treeChildren, treeSuperclasses]);
+  // remember the *initial* selected term so the Aim button can always go back to it
+  const initialSelectedRef = React.useRef(selectedValue?.id || null);
+
+  // keep track of what was selected before a search so Refresh can restore it
+  const preSearchSelectionRef = React.useRef(null);
+  const [searchTerm, setSearchTerm] = React.useState("");
 
   const items = type === CHILDREN ? treeChildren : treeSuperclasses;
   const childCount = items?.[0]?.children?.length || 0;
 
-  const handleSelectChange = (_event, value) => onSelect?.(value);
+  // when selection or type changes, recompute which tree + currentId to show
+  React.useEffect(() => {
+    const focusIri = toIri(selectedValue?.id);
+    const renderedId = findFirstRenderedId(items, focusIri);
+    setCurrentId(renderedId);
+  }, [selectedValue, type, treeChildren, treeSuperclasses]); // mirrors your original logic:contentReference[oaicite:1]{index=1}
+
+  // highlight matches (by id/label/iri) in the rendered tree
+  const highlightedIds = React.useMemo(
+    () => collectMatchingIds(items, searchTerm),
+    [items, searchTerm]
+  );
+
+  // ⬇️ IMPORTANT: selecting from the autocomplete should NOT turn it into a "search mode"
+  // We (1) set upstream selection, (2) clear searchTerm, (3) focus that node in the tree.
+  const handleSelectChange = (value) => {
+    if (!preSearchSelectionRef.current && selectedValue) {
+      preSearchSelectionRef.current = selectedValue;
+    }
+    onSelect?.(value);
+
+    // clear search highlight so the tree doesn't jump/contract
+    setSearchTerm("");
+
+    // focus the selected item in the *current* tree
+    const focusIri = toIri(value?.id);
+    const idInTree = findFirstRenderedId(items, focusIri);
+    if (idInTree) setCurrentId(idInTree);
+  };
+
+  const handleRefresh = () => {
+    // restore selection prior to search; keep hierarchy data intact
+    const toRestore = preSearchSelectionRef.current || initialSelectedRef.current || selectedValue;
+    if (toRestore) {
+      onSelect?.(toRestore);
+      const iri = toIri(toRestore?.id);
+      const idInTree = findFirstRenderedId(items, iri);
+      setCurrentId(idInTree);
+    }
+    setSearchTerm("");
+    preSearchSelectionRef.current = null;
+  };
+
   const gotoFirstOption = () => {
     const opts = type === CHILDREN ? options.children : options.superclasses;
-    if (opts?.length) onSelect?.(opts[0]);
+    if (opts?.length) {
+      onSelect?.(opts[0]);
+      const iri = toIri(opts[0]?.id);
+      const idInTree = findFirstRenderedId(items, iri);
+      setCurrentId(idInTree);
+    }
+    preSearchSelectionRef.current = null;
+    setSearchTerm("");
+  };
+
+  // Aim icon should focus the *original* requested node for the hierarchy (not the last searched)
+  const handleAimFocus = () => {
+    const base = initialSelectedRef.current || selectedValue;
+    const focusIri = toIri(base?.id);
+    const id = findFirstRenderedId(items, focusIri);
+    setCurrentId(id);
   };
 
   const singleSearchOptions = type === CHILDREN ? options.children : options.superclasses;
@@ -83,17 +161,32 @@ const Hierarchy = ({
           <Typography variant="caption" sx={{ fontSize: '0.875rem', color: gray600 }}>Type:</Typography>
           <CustomSingleSelect
             value={type}
-            onChange={(v) => setType(v)}
+            onChange={(v) => {
+              setType(v);
+              // reset only the visual search highlight when switching trees
+              setSearchTerm("");
+            }}
             options={[
               { value: CHILDREN, label: 'Children' },
               { value: SUPERCLASSES, label: 'Superclasses' },
             ]}
           />
           <Divider orientation="vertical" flexItem />
-          <Button sx={{ p: '0.625rem 0.5625rem', minWidth: '0.0625rem' }} variant='outlined' onClick={gotoFirstOption}>
+          <Button
+            sx={{ p: '0.625rem 0.5625rem', minWidth: '0.0625rem' }}
+            variant='outlined'
+            onClick={handleRefresh}
+            title="Restore to the state before search"
+          >
             <RestartAlt />
           </Button>
-          <Button sx={{ p: '0.625rem 0.5625rem', minWidth: '0.0625rem' }} variant='outlined' title="Focus (no-op placeholder)">
+          {/* Previously a no-op placeholder — now focuses the originally requested node:contentReference[oaicite:2]{index=2} */}
+          <Button
+            sx={{ p: '0.625rem 0.5625rem', minWidth: '0.0625rem' }}
+            variant='outlined'
+            onClick={handleAimFocus}
+            title="Highlight original current term"
+          >
             <TargetCross />
           </Button>
         </Stack>
@@ -109,7 +202,8 @@ const Hierarchy = ({
         items={items}
         loading={false}
         currentId={currentId}
-        defaultExpanded={type === CHILDREN ? false : true}
+        highlightedIds={highlightedIds}
+        defaultExpanded={type !== CHILDREN} // superclasses open by default, children collapsed
       />
 
       <Typography color={gray600} fontSize='.875rem'>

--- a/src/components/SingleTermView/OverView/Hierarchy.jsx
+++ b/src/components/SingleTermView/OverView/Hierarchy.jsx
@@ -61,59 +61,47 @@ const collectMatchingIds = (items = [], term = "") => {
 };
 
 const Hierarchy = ({
-  options = { children: [], superclasses: [] }, // {children:[{id,label}], superclasses:[...]}
-  selectedValue,                                 // { id, label }
+  options = { children: [], superclasses: [] }, 
+  selectedValue,                                 
   onSelect,
-  // prebuilt trees (arrays of {id,label,iri,children})
   treeChildren = [],
   treeSuperclasses = [],
   loading = false,
 }) => {
-  const [type, setType] = React.useState(SUPERCLASSES); // default to superclasses
+  const [type, setType] = React.useState(SUPERCLASSES); 
   const [currentId, setCurrentId] = React.useState(null);
-
-  // remember the *initial* selected term so the Aim button can always go back to it
+  const [manualHighlightedIds, setManualHighlightedIds] = React.useState([]);
+  const hasSearchedRef = React.useRef(false);
   const initialSelectedRef = React.useRef(selectedValue?.id || null);
 
-  // keep track of what was selected before a search so Refresh can restore it
   const preSearchSelectionRef = React.useRef(null);
   const [searchTerm, setSearchTerm] = React.useState("");
 
   const items = type === CHILDREN ? treeChildren : treeSuperclasses;
   const childCount = items?.[0]?.children?.length || 0;
 
-  // when selection or type changes, recompute which tree + currentId to show
   React.useEffect(() => {
     const focusIri = toIri(selectedValue?.id);
     const renderedId = findFirstRenderedId(items, focusIri);
     setCurrentId(renderedId);
-  }, [selectedValue, type, treeChildren, treeSuperclasses, items]); // mirrors your original logic:contentReference[oaicite:1]{index=1}
+  }, [selectedValue, type, treeChildren, treeSuperclasses, items]); 
 
-  // highlight matches (by id/label/iri) in the rendered tree
-  const highlightedIds = React.useMemo(
-    () => collectMatchingIds(items, searchTerm),
-    [items, searchTerm]
-  );
-
-  // ⬇️ IMPORTANT: selecting from the autocomplete should NOT turn it into a "search mode"
-  // We (1) set upstream selection, (2) clear searchTerm, (3) focus that node in the tree.
   const handleSelectChange = (value) => {
     if (!preSearchSelectionRef.current && selectedValue) {
       preSearchSelectionRef.current = selectedValue;
     }
     onSelect?.(value);
-
-    // clear search highlight so the tree doesn't jump/contract
-    setSearchTerm("");
-
-    // focus the selected item in the *current* tree
+    hasSearchedRef.current = true;
+  
+    setSearchTerm("");               
+    setManualHighlightedIds([]);       
+  
     const focusIri = toIri(value?.id);
     const idInTree = findFirstRenderedId(items, focusIri);
     if (idInTree) setCurrentId(idInTree);
   };
-
+  
   const handleRefresh = () => {
-    // restore selection prior to search; keep hierarchy data intact
     const toRestore = preSearchSelectionRef.current || initialSelectedRef.current || selectedValue;
     if (toRestore) {
       onSelect?.(toRestore);
@@ -122,24 +110,35 @@ const Hierarchy = ({
       setCurrentId(idInTree);
     }
     setSearchTerm("");
+    setManualHighlightedIds([]);
+    hasSearchedRef.current = false;
     preSearchSelectionRef.current = null;
-  };
+  };  
 
-  // Aim icon should focus the *original* requested node for the hierarchy (not the last searched)
   const handleAimFocus = () => {
-    const base = initialSelectedRef.current || selectedValue;
+    const base = hasSearchedRef.current
+      ? (selectedValue || preSearchSelectionRef.current || { id: initialSelectedRef.current })
+      : (preSearchSelectionRef.current || selectedValue || { id: initialSelectedRef.current });
+  
     const focusIri = toIri(base?.id);
     const id = findFirstRenderedId(items, focusIri);
+  
     setCurrentId(id);
-  };
+    setManualHighlightedIds(id ? [id] : []);  // <-- pass to tree as highlight
+  };  
 
   const singleSearchOptions = type === CHILDREN ? options.children : options.superclasses;
+  const highlightedIdsFromSearch = React.useMemo(
+    () => collectMatchingIds(items, searchTerm),
+    [items, searchTerm]
+  );  
 
   if (loading) {
     return <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
       <CircularProgress />
     </Box>
   }
+
 
   return (
     <Box display='flex' flexDirection='column' gap='1rem'>
@@ -186,12 +185,17 @@ const Hierarchy = ({
         options={singleSearchOptions}
       />
 
+      
       <CustomizedTreeView
         items={items}
         loading={false}
         currentId={currentId}
-        highlightedIds={highlightedIds}
-        defaultExpanded={type !== CHILDREN} // superclasses open by default, children collapsed
+        highlightedIds={
+          highlightedIdsFromSearch.length
+            ? highlightedIdsFromSearch
+            : manualHighlightedIds
+        }
+        defaultExpanded={type !== CHILDREN}
       />
 
       <Typography color={gray600} fontSize='.875rem'>
@@ -208,8 +212,8 @@ Hierarchy.propTypes = {
   }),
   selectedValue: PropTypes.shape({ id: PropTypes.string, label: PropTypes.string }),
   onSelect: PropTypes.func,
-  treeChildren: PropTypes.array,      // array of TreeItem
-  treeSuperclasses: PropTypes.array,  // array of TreeItem
+  treeChildren: PropTypes.array,      
+  treeSuperclasses: PropTypes.array,  
   loading: PropTypes.bool,
 };
 

--- a/src/components/SingleTermView/OverView/Hierarchy.jsx
+++ b/src/components/SingleTermView/OverView/Hierarchy.jsx
@@ -87,7 +87,7 @@ const Hierarchy = ({
     const focusIri = toIri(selectedValue?.id);
     const renderedId = findFirstRenderedId(items, focusIri);
     setCurrentId(renderedId);
-  }, [selectedValue, type, treeChildren, treeSuperclasses]); // mirrors your original logic:contentReference[oaicite:1]{index=1}
+  }, [selectedValue, type, treeChildren, treeSuperclasses, items]); // mirrors your original logic:contentReference[oaicite:1]{index=1}
 
   // highlight matches (by id/label/iri) in the rendered tree
   const highlightedIds = React.useMemo(
@@ -123,18 +123,6 @@ const Hierarchy = ({
     }
     setSearchTerm("");
     preSearchSelectionRef.current = null;
-  };
-
-  const gotoFirstOption = () => {
-    const opts = type === CHILDREN ? options.children : options.superclasses;
-    if (opts?.length) {
-      onSelect?.(opts[0]);
-      const iri = toIri(opts[0]?.id);
-      const idInTree = findFirstRenderedId(items, iri);
-      setCurrentId(idInTree);
-    }
-    preSearchSelectionRef.current = null;
-    setSearchTerm("");
   };
 
   // Aim icon should focus the *original* requested node for the hierarchy (not the last searched)

--- a/src/components/SingleTermView/OverView/OverView.jsx
+++ b/src/components/SingleTermView/OverView/OverView.jsx
@@ -141,7 +141,7 @@ const OverView = ({ searchTerm, isCodeViewVisible = false, selectedDataFormat, g
       setPredicateGroups(groups || []);
     } catch (e) {
       console.error("fetchPredicates error:", e);
-      setPredicateGroups([]);
+      setLoadingPredicates(false);
     } finally {
       setLoadingPredicates(false);
     }

--- a/src/components/common/CustomizedTreeView.jsx
+++ b/src/components/common/CustomizedTreeView.jsx
@@ -222,7 +222,9 @@ const CustomizedTreeView = ({
       getItemLabel={getItemLabel}
       getItemChildren={getItemChildren}
       expandedItems={expanded}
-      onExpandedItemsChange={(_e, ids) => setExpanded(ids)}  // user can toggle
+      onExpandedItemsChange={(_e, ids) => setExpanded(ids)}
+      selectedItems={currentId ? [currentId] : []}
+      onSelectedItemsChange={() => { /* keep selection controlled by currentId */ }}
       slots={{
         item: StyledTreeItemBase,
         expandIcon: ChevronRightOutlinedIcon,

--- a/src/components/common/CustomizedTreeView.jsx
+++ b/src/components/common/CustomizedTreeView.jsx
@@ -1,48 +1,113 @@
 import PropTypes from 'prop-types';
-import { Box, Chip, CircularProgress } from "@mui/material";
+import { Box, Chip, CircularProgress, IconButton, Tooltip } from "@mui/material";
 import { styled } from '@mui/material/styles';
 import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
 import { TreeItem, treeItemClasses } from '@mui/x-tree-view/TreeItem';
 import ExpandLessOutlinedIcon from '@mui/icons-material/ExpandLessOutlined';
 import ChevronRightOutlinedIcon from '@mui/icons-material/ChevronRightOutlined';
+import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
 import { useEffect, useMemo, useRef, useState } from "react";
 import { vars } from "../../theme/variables";
 
 const { gray500, brand200, brand50 } = vars;
 
-const StyledTreeItemBase = (props) => (
-  <TreeItem
-    {...props}
-    label={
-      <Box display='flex' alignItems='center' gap='.5rem'>
-        <span>{props.label}</span>
-        {props.currentId && props.itemId === props.currentId && (
-          <Chip
-            className="rounded"
-            variant="outlined"
-            label={'Current Item'}
-            sx={{ borderColor: brand200, backgroundColor: brand50 }}
-          />
-        )}
-      </Box>
-    }
-  />
-);
+const StyledLabel = styled('span')(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '.5rem',
+  position: 'relative'
+}));
+
+const HoverActions = styled('span')(() => ({
+  display: 'none',
+  alignItems: 'center',
+  marginLeft: '0.25rem'
+}));
+
+const StyledTreeItemBase = (props) => {
+  const {
+    label,
+    currentId,
+    highlightedIds,
+    itemId,
+    idToIri,
+    idToHasChildren
+  } = props;
+
+  const isCurrent = currentId && itemId === currentId;
+  const isHighlighted = Array.isArray(highlightedIds) && highlightedIds.includes(itemId);
+  const isLeaf = idToHasChildren?.get(itemId) === false;
+
+  const iri = idToIri?.get(itemId) || itemId;
+
+  return (
+    <TreeItem
+      {...props}
+      label={
+        <StyledLabel className="tree-item-label">
+          <span style={{ fontWeight: isHighlighted ? 600 : 400 }}>
+            {label}
+          </span>
+
+          {isCurrent && (
+            <Chip
+              className="rounded"
+              variant="outlined"
+              label={'Current Item'}
+              sx={{ borderColor: brand200, backgroundColor: brand50 }}
+              size="small"
+            />
+          )}
+
+          {isHighlighted && !isCurrent && (
+            <Chip
+              className="rounded"
+              variant="outlined"
+              label={'Match'}
+              sx={{ borderColor: brand200, backgroundColor: brand50 }}
+              size="small"
+            />
+          )}
+
+          {/* Leaf-only hover action: open in new tab */}
+          {isLeaf && (
+            <HoverActions className="hover-actions">
+              <Tooltip title="Open term in new tab">
+                <IconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    try {
+                      window.open(iri, "_blank", "noopener,noreferrer");
+                    } catch {
+                      window.open(String(iri), "_blank");
+                    }
+                  }}
+                >
+                  <OpenInNewOutlinedIcon fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+            </HoverActions>
+          )}
+        </StyledLabel>
+      }
+      sx={{
+        [`& .${treeItemClasses.content}:hover .hover-actions`]: { display: 'inline-flex' },
+        [`& .${treeItemClasses.label}`]: { fontSize: '0.875rem', fontWeight: 400 },
+        color: gray500,
+      }}
+    />
+  );
+};
 
 StyledTreeItemBase.propTypes = {
   label: PropTypes.string,
   currentId: PropTypes.string,
-  itemId: PropTypes.string
+  highlightedIds: PropTypes.arrayOf(PropTypes.string),
+  itemId: PropTypes.string,
+  idToIri: PropTypes.instanceOf(Map),
+  idToHasChildren: PropTypes.instanceOf(Map)
 };
-
-
-const StyledTreeItem = styled(StyledTreeItemBase)(() => ({
-  color: gray500,
-  [`& .${treeItemClasses.content}`]: {
-    [`& .${treeItemClasses.label}`]: { fontSize: '0.875rem', fontWeight: 400 },
-  },
-  [`& .${treeItemClasses.groupTransition}`]: { marginLeft: 14 },
-}));
 
 const kidsOf = (n, getItemChildren) => {
   const k = getItemChildren(n);
@@ -64,11 +129,32 @@ const CustomizedTreeView = ({
   items = [],
   loading = false,
   currentId = null,
+  highlightedIds = [],
   getItemId = (i) => i.id,
   getItemLabel = (i) => i.label,
   getItemChildren = (i) => i.children || [],
+  defaultExpanded = false
 }) => {
   const [expanded, setExpanded] = useState([]);
+
+  // precompute roots for safety (keeps tree visible even if expanded becomes empty)
+  const rootIds = useMemo(() => (items || []).map(getItemId), [items, getItemId]);
+
+  // index useful metadata for slots (fast lookups in item renderer)
+  const { idToIri, idToHasChildren } = useMemo(() => {
+    const iriMap = new Map();
+    const hasChildrenMap = new Map();
+    const stack = [...items];
+    while (stack.length) {
+      const node = stack.pop();
+      const id = getItemId(node);
+      const kids = kidsOf(node, getItemChildren);
+      iriMap.set(id, node?.iri ?? null);
+      hasChildrenMap.set(id, kids.length > 0);
+      stack.push(...kids);
+    }
+    return { idToIri: iriMap, idToHasChildren: hasChildrenMap };
+  }, [items, getItemChildren, getItemId]);
 
   // compute path to current node
   const pathToCurrent = useMemo(
@@ -76,16 +162,49 @@ const CustomizedTreeView = ({
     [items, currentId, getItemId, getItemChildren]
   );
 
-  // only auto-expand when the path actually changes
-  const pathKey = useMemo(() => pathToCurrent.join('|'), [pathToCurrent]);
-  const lastPathKeyRef = useRef('');
-  useEffect(() => {
-    if (pathKey && pathKey !== lastPathKeyRef.current) {
-      const ancestors = pathToCurrent.slice(0, -1);
-      setExpanded(ancestors);                // set once per path change
-      lastPathKeyRef.current = pathKey;
+  // also expand ancestors of matched nodes so highlights are visible
+  const matchAncestorIds = useMemo(() => {
+    if (!highlightedIds?.length) return [];
+    const set = new Set();
+    const dfs = (nodes, ancestors = []) => {
+      for (const n of nodes || []) {
+        const id = getItemId(n);
+        const nextAncestors = [...ancestors, id];
+        if (highlightedIds.includes(id)) nextAncestors.forEach(a => set.add(a));
+        dfs(getItemChildren(n), nextAncestors);
+      }
+    };
+    dfs(items, []);
+    return [...set];
+  }, [items, highlightedIds, getItemChildren, getItemId]);
+
+  // desired expansions: keep visibility of current and matches; retain user toggles
+  const desiredExpanded = useMemo(() => {
+    const ancestorsOfCurrent = pathToCurrent.slice(0, -1);
+    if (defaultExpanded === true) {
+      // superclasses: open roots initially; ensure ancestors for matches/current are open too
+      return Array.from(new Set([...rootIds, ...ancestorsOfCurrent, ...matchAncestorIds]));
     }
-  }, [pathKey, pathToCurrent]);
+    // children: collapsed by default, but still ensure current/match ancestors are visible
+    return Array.from(new Set([...ancestorsOfCurrent, ...matchAncestorIds]));
+  }, [defaultExpanded, pathToCurrent, matchAncestorIds, rootIds]);
+
+  // only adjust expansions when the derived set changes — merge with existing so tree never "disappears"
+  const desiredKey = useMemo(() => desiredExpanded.join('|'), [desiredExpanded]);
+  const lastKey = useRef('');
+  useEffect(() => {
+    if (desiredKey !== lastKey.current) {
+      setExpanded(prev => {
+        const merged = new Set([...(prev || []), ...desiredExpanded]);
+        // As a final guard: if merged is empty but we want roots visible for defaultExpanded=true
+        if (merged.size === 0 && defaultExpanded === true && rootIds.length) {
+          rootIds.forEach(id => merged.add(id));
+        }
+        return [...merged];
+      });
+      lastKey.current = desiredKey;
+    }
+  }, [desiredKey, desiredExpanded, defaultExpanded, rootIds]);
 
   if (loading) {
     return (
@@ -105,11 +224,18 @@ const CustomizedTreeView = ({
       expandedItems={expanded}
       onExpandedItemsChange={(_e, ids) => setExpanded(ids)}  // user can toggle
       slots={{
-        item: StyledTreeItem,
+        item: StyledTreeItemBase,
         expandIcon: ChevronRightOutlinedIcon,
         collapseIcon: ExpandLessOutlinedIcon,
       }}
-      slotProps={{ item: { currentId } }}
+      slotProps={{
+        item: {
+          currentId,
+          highlightedIds,
+          idToIri,
+          idToHasChildren
+        }
+      }}
     />
   );
 };
@@ -118,9 +244,11 @@ CustomizedTreeView.propTypes = {
   items: PropTypes.array,
   loading: PropTypes.bool,
   currentId: PropTypes.string,
+  highlightedIds: PropTypes.arrayOf(PropTypes.string),
   getItemId: PropTypes.func,
   getItemLabel: PropTypes.func,
   getItemChildren: PropTypes.func,
+  defaultExpanded: PropTypes.bool
 };
 
 export default CustomizedTreeView;

--- a/src/parsers/hierarchies-parser.tsx
+++ b/src/parsers/hierarchies-parser.tsx
@@ -1,6 +1,6 @@
 export const ILX_PART_OF = 'Is part of';
 export const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
-export const OWL_OBJECT_PROPERTY = 'owl:ObjectProperty';
+export const OWL_OBJECT_PROPERTY = 'owl:';
 
 export const RDFS_LABEL = 'http://www.w3.org/2000/01/rdf-schema#label';
 export const PART_OF_IRI = 'http://uri.interlex.org/base/ilx_0112785';
@@ -212,8 +212,10 @@ export const toHierarchyOptionsFromTriples = (triples: Triple[] = []) => {
   const labelMap = buildLabelMap(triples);
   const ids = new Set<string>();
   for (const t of triples) {
-    if (t.subject?.id) ids.add(toIri(t.subject.id));
-    if (t.object?.id) ids.add(toIri(t.object.id));
+    if ( t.object?.id !== "" && !t.object?.id?.includes(OWL_OBJECT_PROPERTY)  && !t.subject?.id?.includes(OWL_OBJECT_PROPERTY) ) {
+      if (t.subject?.id) ids.add(toIri(t.subject.id));
+      if (t.object?.id) ids.add(toIri(t.object.id));
+    }
   }
   const out = Array.from(ids).map((iri) => ({ id: iri, label: labelOf(iri, labelMap) }));
   // stable order: label asc


### PR DESCRIPTION
This pull request introduces significant improvements to the hierarchy tree component and its integration, focusing on enhanced search/filtering, better navigation and selection handling, and improved user experience through visual feedback and actions. The changes are mainly in `Hierarchy.jsx` and `CustomizedTreeView.jsx`, with supporting updates in related files.

**Hierarchy filtering and navigation enhancements:**

* Added a new `collectMatchingIds` function to support filtering tree items by id, label, or IRI, enabling search highlights within the hierarchy tree.
* Refactored selection logic in `Hierarchy` to remember the initial selected term, track pre-search selection, and provide "Refresh" and "Aim" buttons for restoring and focusing hierarchy states. [[1]](diffhunk://#diff-d69699d2931466184378d7fc94a73d142e0a5070eb9fd28fc31c77b733385c7bR75-R145) [[2]](diffhunk://#diff-d69699d2931466184378d7fc94a73d142e0a5070eb9fd28fc31c77b733385c7bL86-R189)
* Integrated search term highlighting and improved tree expansion logic to ensure matched and selected nodes are visible, including auto-expansion of relevant ancestors. [[1]](diffhunk://#diff-d69699d2931466184378d7fc94a73d142e0a5070eb9fd28fc31c77b733385c7bL112-R206) [[2]](diffhunk://#diff-d125e26bf28530ef80bd0015a705bdba7e8129e02f0345999c63c4112d7e35b9R132-R207)

**User interface and experience improvements:**

* Enhanced tree item rendering in `CustomizedTreeView`: added visual chips for "Current Item" and "Match", and introduced a hover action to open leaf nodes in a new tab.
* Updated props and slot handling to support new features, including passing highlighted IDs and metadata for improved rendering and interaction. [[1]](diffhunk://#diff-d125e26bf28530ef80bd0015a705bdba7e8129e02f0345999c63c4112d7e35b9L108-R238) [[2]](diffhunk://#diff-d125e26bf28530ef80bd0015a705bdba7e8129e02f0345999c63c4112d7e35b9R247-R251)

**Bug fix:**

* Fixed a loading state bug in predicate fetching by ensuring `setLoadingPredicates(false)` is called on error in `OverView.jsx`.